### PR TITLE
Refresh GCVE homepage styling

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,0 +1,310 @@
+:root {
+  --gcve-ink: #10233f;
+  --gcve-muted: #526178;
+  --gcve-blue: #2664ff;
+  --gcve-cyan: #22c3df;
+  --gcve-lime: #94d82d;
+  --gcve-violet: #7c3aed;
+  --gcve-card: rgba(255, 255, 255, 0.82);
+  --gcve-border: rgba(38, 100, 255, 0.16);
+  --gcve-shadow: 0 24px 80px rgba(16, 35, 63, 0.12);
+}
+
+.dark {
+  --gcve-ink: #f7fbff;
+  --gcve-muted: #b5c3d8;
+  --gcve-card: rgba(18, 24, 38, 0.76);
+  --gcve-border: rgba(34, 195, 223, 0.22);
+  --gcve-shadow: 0 24px 80px rgba(0, 0, 0, 0.35);
+}
+
+body {
+  background:
+    radial-gradient(circle at top left, rgba(34, 195, 223, 0.14), transparent 34rem),
+    radial-gradient(circle at top right, rgba(148, 216, 45, 0.13), transparent 30rem),
+    linear-gradient(180deg, rgba(248, 252, 255, 0.95), rgba(255, 255, 255, 1) 28rem);
+}
+
+.dark body {
+  background:
+    radial-gradient(circle at top left, rgba(34, 195, 223, 0.18), transparent 34rem),
+    radial-gradient(circle at top right, rgba(124, 58, 237, 0.16), transparent 30rem),
+    linear-gradient(180deg, #080d18, #0c1220 30rem);
+}
+
+.nav-container-blur {
+  border-bottom: 1px solid rgba(38, 100, 255, 0.08);
+  box-shadow: 0 10px 32px rgba(16, 35, 63, 0.05);
+}
+
+.dark .nav-container-blur {
+  border-bottom-color: rgba(255, 255, 255, 0.08);
+  box-shadow: 0 10px 32px rgba(0, 0, 0, 0.24);
+}
+
+.content :is(h1, h2, h3) {
+  letter-spacing: -0.035em;
+}
+
+.gcve-hero {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  margin: 1.5rem 0 3rem;
+  padding: clamp(2rem, 5vw, 4.75rem);
+  border: 1px solid var(--gcve-border);
+  border-radius: 2rem;
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(255, 255, 255, 0.66)),
+    radial-gradient(circle at 85% 20%, rgba(34, 195, 223, 0.24), transparent 18rem),
+    radial-gradient(circle at 8% 90%, rgba(148, 216, 45, 0.2), transparent 16rem);
+  box-shadow: var(--gcve-shadow);
+}
+
+.dark .gcve-hero {
+  background:
+    linear-gradient(135deg, rgba(12, 18, 32, 0.94), rgba(18, 24, 38, 0.78)),
+    radial-gradient(circle at 85% 20%, rgba(34, 195, 223, 0.18), transparent 18rem),
+    radial-gradient(circle at 8% 90%, rgba(124, 58, 237, 0.22), transparent 16rem);
+}
+
+.gcve-hero::before,
+.gcve-hero::after {
+  content: "";
+  position: absolute;
+  z-index: -1;
+  border-radius: 999px;
+  filter: blur(1px);
+}
+
+.gcve-hero::before {
+  width: 18rem;
+  height: 18rem;
+  right: -5rem;
+  top: -5rem;
+  background: conic-gradient(from 160deg, rgba(34, 195, 223, 0.5), rgba(38, 100, 255, 0.22), rgba(148, 216, 45, 0.36), rgba(34, 195, 223, 0.5));
+  opacity: 0.78;
+}
+
+.gcve-hero::after {
+  width: 12rem;
+  height: 12rem;
+  left: -4rem;
+  bottom: -4rem;
+  background: linear-gradient(135deg, rgba(38, 100, 255, 0.26), rgba(34, 195, 223, 0.2));
+}
+
+.gcve-hero-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.25fr) minmax(260px, 0.75fr);
+  gap: clamp(2rem, 5vw, 4rem);
+  align-items: center;
+}
+
+.gcve-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0 0 1rem;
+  padding: 0.4rem 0.75rem;
+  border: 1px solid rgba(34, 195, 223, 0.24);
+  border-radius: 999px;
+  background: rgba(34, 195, 223, 0.1);
+  color: #0b7285;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.dark .gcve-eyebrow {
+  color: #8be9f7;
+  background: rgba(34, 195, 223, 0.13);
+}
+
+.gcve-hero h1 {
+  margin: 0;
+  max-width: 11ch;
+  color: var(--gcve-ink);
+  font-size: clamp(3rem, 8vw, 6rem);
+  line-height: 0.92;
+  letter-spacing: -0.075em;
+}
+
+.gcve-gradient-text {
+  background: linear-gradient(90deg, var(--gcve-blue), var(--gcve-cyan) 48%, #65a30d);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.gcve-hero-lede {
+  max-width: 46rem;
+  margin: 1.4rem 0 0;
+  color: var(--gcve-muted);
+  font-size: clamp(1.08rem, 2vw, 1.35rem);
+  line-height: 1.65;
+}
+
+.gcve-hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+  margin-top: 2rem;
+}
+
+.gcve-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  min-height: 2.9rem;
+  padding: 0.7rem 1.05rem;
+  border-radius: 999px;
+  font-weight: 750;
+  text-decoration: none !important;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.gcve-button:hover {
+  transform: translateY(-2px);
+}
+
+.gcve-button-primary {
+  color: #fff !important;
+  background: linear-gradient(135deg, var(--gcve-blue), var(--gcve-cyan));
+  box-shadow: 0 14px 34px rgba(38, 100, 255, 0.28);
+}
+
+.gcve-button-secondary {
+  border: 1px solid var(--gcve-border);
+  color: var(--gcve-ink) !important;
+  background: rgba(255, 255, 255, 0.66);
+}
+
+.dark .gcve-button-secondary {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.gcve-hero-panel {
+  position: relative;
+  padding: 1.25rem;
+  border: 1px solid var(--gcve-border);
+  border-radius: 1.5rem;
+  background: var(--gcve-card);
+  box-shadow: 0 18px 54px rgba(16, 35, 63, 0.11);
+  backdrop-filter: blur(18px);
+}
+
+.gcve-hero-panel img {
+  width: min(100%, 320px);
+  margin: 0 auto 1rem;
+  display: block;
+}
+
+.gcve-stat-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.gcve-stat {
+  padding: 1rem;
+  border: 1px solid rgba(38, 100, 255, 0.11);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.58);
+}
+
+.dark .gcve-stat {
+  border-color: rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.gcve-stat strong {
+  display: block;
+  color: var(--gcve-ink);
+  font-size: 1.4rem;
+  line-height: 1;
+}
+
+.gcve-stat span {
+  display: block;
+  margin-top: 0.35rem;
+  color: var(--gcve-muted);
+  font-size: 0.85rem;
+  line-height: 1.35;
+}
+
+.gcve-section-intro {
+  max-width: 48rem;
+  margin: 0 0 1.25rem;
+  color: var(--gcve-muted);
+  font-size: 1.05rem;
+  line-height: 1.65;
+}
+
+.hextra-cards {
+  gap: 1rem !important;
+}
+
+.hextra-card {
+  border-color: var(--gcve-border) !important;
+  border-radius: 1.15rem !important;
+  background: var(--gcve-card) !important;
+  box-shadow: 0 16px 38px rgba(16, 35, 63, 0.07) !important;
+  backdrop-filter: blur(14px);
+}
+
+.hextra-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(135deg, rgba(38, 100, 255, 0.11), rgba(34, 195, 223, 0.08), transparent 58%);
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  pointer-events: none;
+}
+
+.hextra-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(34, 195, 223, 0.42) !important;
+  box-shadow: 0 24px 54px rgba(16, 35, 63, 0.13) !important;
+}
+
+.hextra-card:hover::before {
+  opacity: 1;
+}
+
+.hextra-card svg {
+  color: var(--gcve-blue) !important;
+}
+
+.hextra-card-subtitle {
+  line-clamp: unset !important;
+  -webkit-line-clamp: unset !important;
+}
+
+.content img[src$="/logos/gcve.png"]:not(.gcve-hero img) {
+  max-width: 260px;
+  margin-inline: auto;
+}
+
+@media (max-width: 768px) {
+  .gcve-hero {
+    border-radius: 1.35rem;
+    margin-top: 0.75rem;
+  }
+
+  .gcve-hero-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .gcve-hero-panel {
+    order: -1;
+  }
+
+  .gcve-hero h1 {
+    max-width: 100%;
+  }
+}

--- a/content/_index.md
+++ b/content/_index.md
@@ -3,23 +3,45 @@ title: "GCVE initiative - Global CVE Allocation System"
 toc: false
 ---
 
-![Logo of the GCVE.eu - Global CVE Allocation System](/logos/gcve.png) 
+<section class="gcve-hero">
+  <div class="gcve-hero-grid">
+    <div>
+      <p class="gcve-eyebrow">Decentralized vulnerability identifiers</p>
+      <h1>Global CVE <span class="gcve-gradient-text">Allocation</span></h1>
+      <p class="gcve-hero-lede">GCVE is a fresh, open approach to vulnerability identification and numbering: compatible with CVE, designed for distributed publication, and built around autonomous GCVE Numbering Authorities.</p>
+      <div class="gcve-hero-actions">
+        <a class="gcve-button gcve-button-primary" href="/about/">Explore GCVE</a>
+        <a class="gcve-button gcve-button-secondary" href="https://db.gcve.eu/">Open db.gcve.eu</a>
+      </div>
+    </div>
+    <div class="gcve-hero-panel" aria-label="GCVE at a glance">
+      <img src="/logos/gcve.png" alt="GCVE logo" />
+      <div class="gcve-stat-grid">
+        <div class="gcve-stat"><strong>GNA</strong><span>Independent numbering authorities</span></div>
+        <div class="gcve-stat"><strong>BCP</strong><span>Open best current practices</span></div>
+        <div class="gcve-stat"><strong>JSON</strong><span>Machine-readable directory</span></div>
+        <div class="gcve-stat"><strong>EU</strong><span>Community-led coordination</span></div>
+      </div>
+    </div>
+  </div>
+</section>
 
-The **Global CVE (GCVE)** allocation system is a new, decentralized approach to vulnerability identification and numbering, designed to improve flexibility, scalability, and autonomy for participating entities. 
+The **Global CVE (GCVE)** allocation system is a new, decentralized approach to vulnerability identification and numbering, designed to improve flexibility, scalability, and autonomy for participating entities.
 
 While remaining compatible with the traditional CVE system, GCVE introduces **GCVE Numbering Authorities (GNAs)**. GNAs are independent entities that can allocate identifiers without relying on a centralised block distribution system or rigid policy enforcement.
 
-## Explore
+## Explore GCVE
+
+<p class="gcve-section-intro">Start with the core concepts, follow the latest updates, or jump directly to the machine-readable data and vulnerability intelligence services.</p>
 
 {{< cards >}}
-  {{< card link="about" title="About" icon="book-open" >}}
-  {{< card link="faq" title="FAQ" icon="chat" >}}
-  {{< card link="bcp" title="BCP" icon="book-open" >}}
-  {{< card link="software" title="Software" icon="desktop-computer" >}}
-  {{< card link="gna" title="GNA Directory" icon="book-open" >}}
-  {{< card link="/dist/gcve.json" title="GCVE GNA Directory File" icon="desktop-computer" >}}
-  {{< card link="news" title="News" icon="newspaper" >}}
-  {{< card link="https://db.gcve.eu" title="db.gcve.eu" icon="database" >}}
-  {{< card link="contact" title="Contact" icon="mail" >}}
+  {{< card link="about" title="About GCVE" icon="book-open" subtitle="Understand the goals, design principles, and decentralized allocation model." >}}
+  {{< card link="faq" title="FAQ" icon="chat" subtitle="Quick answers about compatibility, identifiers, GNAs, and participation." >}}
+  {{< card link="bcp" title="Best Current Practices" icon="book-open" subtitle="Read the open process documents that guide GCVE operations." >}}
+  {{< card link="software" title="Software" icon="desktop-computer" subtitle="Discover implementations, tooling, and integrations around the ecosystem." >}}
+  {{< card link="gna" title="GNA Directory" icon="book-open" subtitle="Browse participating GCVE Numbering Authorities and related metadata." >}}
+  {{< card link="/dist/gcve.json" title="Directory JSON" icon="desktop-computer" subtitle="Fetch the GCVE GNA directory as a machine-readable file." >}}
+  {{< card link="news" title="News" icon="newspaper" subtitle="Follow announcements, releases, community events, and project updates." >}}
+  {{< card link="https://db.gcve.eu" title="db.gcve.eu" icon="database" subtitle="Open the GCVE vulnerability intelligence and lookup service." >}}
+  {{< card link="contact" title="Contact" icon="mail" subtitle="Reach the GCVE team and join community discussion channels." >}}
 {{< /cards >}}
-


### PR DESCRIPTION
### Motivation
- Give the GCVE homepage a fresher, more modern look with a clear hero, stronger CTA treatment, and improved visual hierarchy. 
- Surface key project entry points (GNA, BCP, JSON, db.gcve.eu) prominently to help visitors discover resources quickly. 
- Provide a compact set of reusable style tokens and glassy UI elements that work in light and dark modes.

### Description
- Add new stylesheet `assets/css/custom.css` containing design tokens, light/dark backgrounds, hero layout, buttons, stat cards, and Hextra card refinements. 
- Replace the simple logo image on the homepage with a structured hero block in `content/_index.md` that includes an eyebrow, gradient headline, lede, primary/secondary CTAs, logo panel, and four quick stat tiles. 
- Enhance Hextra card presentation by adjusting borders, radii, background, hover lift, gradient overlays, and icon color in the new custom CSS to match the refreshed visual system. 
- Include responsive behavior and sensible defaults for mobile screens and prefer system-aware dark mode handling.

### Testing
- Ran a Python sanity check (`python3 -c ...`) that validated the presence of key markers in the homepage and that CSS braces are balanced, and it passed. 
- Performed `git diff --check` to catch whitespace/formatting issues and no problems were reported. 
- Attempted to run `hugo version` to perform a local build but Hugo is not available in the environment so a full site build was not executed. 
- Attempted to install/run Hugo (`go install github.com/gohugoio/hugo@v0.148.2` and `npx --yes hugo version`) but those fetched from remote registries failed due to environment/proxy `403` errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2520302f348324962c480bb2c09139)