### PR TITLE
Expand GCVE website layout

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -8,6 +8,7 @@
   --gcve-card: rgba(255, 255, 255, 0.82);
   --gcve-border: rgba(38, 100, 255, 0.16);
   --gcve-shadow: 0 24px 80px rgba(16, 35, 63, 0.12);
+  --gcve-page-max: 88rem;
 }
 
 .dark {
@@ -44,6 +45,13 @@ body {
 
 .content :is(h1, h2, h3) {
   letter-spacing: -0.035em;
+}
+
+/* Let GCVE pages use the available viewport instead of staying in a narrow
+   centered column on large displays. Hextra applies the max-width utility to
+   the page <main>, including the homepage hero shown above the fold. */
+.hx-max-w-6xl {
+  max-width: var(--gcve-page-max) !important;
 }
 
 .gcve-hero {
@@ -96,7 +104,7 @@ body {
 
 .gcve-hero-grid {
   display: grid;
-  grid-template-columns: minmax(0, 1.25fr) minmax(260px, 0.75fr);
+  grid-template-columns: minmax(34rem, 1.25fr) minmax(320px, 0.75fr);
   gap: clamp(2rem, 5vw, 4rem);
   align-items: center;
 }
@@ -124,9 +132,11 @@ body {
 
 .gcve-hero h1 {
   margin: 0;
-  max-width: 11ch;
+  max-width: 13ch;
   color: var(--gcve-ink);
-  font-size: clamp(3rem, 8vw, 6rem);
+  overflow-wrap: normal;
+  word-break: normal;
+  font-size: clamp(3rem, 6vw, 5.6rem);
   line-height: 0.92;
   letter-spacing: -0.075em;
 }
@@ -288,6 +298,12 @@ body {
 .content img[src$="/logos/gcve.png"]:not(.gcve-hero img) {
   max-width: 260px;
   margin-inline: auto;
+}
+
+@media (max-width: 1024px) {
+  .gcve-hero-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
 }
 
 @media (max-width: 768px) {

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -89,7 +89,7 @@ menu:
 params:
   page:
     # full (100%), wide (90rem), normal (1280px)
-    width: normal
+    width: wide
 
   navbar:
     displayTitle: true


### PR DESCRIPTION
### Motivation
- The site used a relatively narrow centered content column on large screens which caused the homepage hero headline to wrap awkwardly and left excessive unused space on wide displays.

### Description
- Updated `hugo.yaml` to set the default page width to `wide` so pages can use the theme's larger layout instead of the constrained `normal` width.
- Added a CSS variable `--gcve-page-max` and an override for Hextra's `.hx-max-w-6xl` in `assets/css/custom.css` to increase the effective max-width to `88rem` for GCVE pages.
- Widened the homepage hero grid and increased its column minima to `minmax(34rem, 1.25fr)` / `minmax(320px, 0.75fr)` to give the hero content more space on large viewports.
- Tuned the hero headline (`h1`) max-width and font sizing and added a tablet breakpoint so the hero collapses cleanly at medium sizes.

### Testing
- Ran `git diff --check` which reported no whitespace or diff errors.
- Attempted `hugo version` which failed because Hugo is not installed in the environment (`hugo: command not found`).
- Attempted to install Hugo with `go install github.com/gohugoio/hugo@v0.127.0` which was blocked by the Go proxy (403 response).
- Attempted `apt-get update && apt-get install -y hugo` which failed due to 403 responses from the configured apt/proxy endpoints.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25258376d8832494cc4226060c0984)