### PR TITLE
Fix homepage hero panel overflow

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -58,6 +58,8 @@ body {
   position: relative;
   isolation: isolate;
   overflow: hidden;
+  width: 100%;
+  box-sizing: border-box;
   margin: 1.5rem 0 3rem;
   padding: clamp(2rem, 5vw, 4.75rem);
   border: 1px solid var(--gcve-border);
@@ -104,8 +106,8 @@ body {
 
 .gcve-hero-grid {
   display: grid;
-  grid-template-columns: minmax(34rem, 1.25fr) minmax(320px, 0.75fr);
-  gap: clamp(2rem, 5vw, 4rem);
+  grid-template-columns: minmax(0, 1.25fr) minmax(16rem, 0.75fr);
+  gap: clamp(1.5rem, 4vw, 4rem);
   align-items: center;
 }
 
@@ -300,7 +302,7 @@ body {
   margin-inline: auto;
 }
 
-@media (max-width: 1024px) {
+@media (max-width: 1024px), (min-width: 1025px) and (max-width: 1280px) {
   .gcve-hero-grid {
     grid-template-columns: minmax(0, 1fr);
   }


### PR DESCRIPTION
### Motivation
- The right-side panel inside the homepage hero could be pushed outside or clipped on wide displays and intermediate widths, causing the “box in the box” to be partially hidden.
- The layout used fixed minimum column widths that didn't adapt well to constrained content widths, which led to overflow and clipping in some viewports.
- The change aims to ensure the hero panel is always visible across a wider range of screen sizes and layouts.

### Description
- Updated `assets/css/custom.css` to make the `.gcve-hero` container use full available width and `box-sizing: border-box` so padding/borders are included in its width calculation.
- Relaxed the hero grid column minimums and reduced the responsive gap by changing `grid-template-columns` from `minmax(34rem, 1.25fr) minmax(320px, 0.75fr)` to `minmax(0, 1.25fr) minmax(16rem, 0.75fr)` and `gap` to `clamp(1.5rem, 4vw, 4rem)` so the nested panel no longer gets clipped.
- Broadened the stacked layout breakpoint by changing the media query to `@media (max-width: 1024px), (min-width: 1025px) and (max-width: 1280px)` so the hero grid stacks up to 1280px when needed.

### Testing
- Ran `git diff --check` and it completed successfully.
- Performed a CSS sanity check via `python3` (brace-balance script) and it returned a balanced result.
- Attempted to run `hugo` but it could not be executed in this environment because Hugo is not installed (test not run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2526e568408324b5d89b54a6708145)