### PR TITLE
Polish top header/navbar for improved readability and responsiveness

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -43,6 +43,160 @@ body {
   box-shadow: 0 10px 32px rgba(0, 0, 0, 0.24);
 }
 
+.gcve-navbar {
+  --gcve-nav-surface: rgba(255, 255, 255, 0.64);
+  --gcve-nav-surface-strong: rgba(255, 255, 255, 0.92);
+  --gcve-nav-text: #22324a;
+  --gcve-nav-subtle: #64748b;
+}
+
+.dark .gcve-navbar {
+  --gcve-nav-surface: rgba(255, 255, 255, 0.055);
+  --gcve-nav-surface-strong: rgba(18, 24, 38, 0.92);
+  --gcve-nav-text: #e8f1fb;
+  --gcve-nav-subtle: #9fb0c7;
+}
+
+.gcve-brand {
+  min-width: 0;
+  color: var(--gcve-nav-text);
+  text-decoration: none;
+}
+
+.gcve-brand-mark {
+  display: inline-grid;
+  flex: 0 0 auto;
+  place-items: center;
+  width: 2.45rem;
+  height: 2.45rem;
+  border: 1px solid rgba(38, 100, 255, 0.15);
+  border-radius: 0.9rem;
+  background:
+    radial-gradient(circle at 70% 20%, rgba(34, 195, 223, 0.28), transparent 55%),
+    var(--gcve-nav-surface-strong);
+  box-shadow: 0 10px 28px rgba(16, 35, 63, 0.08);
+}
+
+.dark .gcve-brand-mark {
+  border-color: rgba(34, 195, 223, 0.22);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.22);
+}
+
+.gcve-brand-mark img {
+  width: 1.65rem;
+  height: 1.65rem;
+}
+
+.gcve-brand-copy {
+  display: grid;
+  min-width: 0;
+  line-height: 1.05;
+}
+
+.gcve-brand-title {
+  color: var(--gcve-nav-text);
+  font-size: 1.02rem;
+  font-weight: 850;
+  letter-spacing: -0.025em;
+}
+
+.gcve-brand-subtitle {
+  margin-top: 0.14rem;
+  color: var(--gcve-nav-subtle);
+  font-size: 0.72rem;
+  font-weight: 650;
+  letter-spacing: 0.015em;
+  white-space: nowrap;
+}
+
+.gcve-nav-links,
+.gcve-icon-links {
+  padding: 0.22rem;
+  border: 1px solid rgba(38, 100, 255, 0.11);
+  border-radius: 999px;
+  background: var(--gcve-nav-surface);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.46);
+}
+
+.dark .gcve-nav-links,
+.dark .gcve-icon-links {
+  border-color: rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+.gcve-nav-link,
+.gcve-icon-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.42rem;
+  min-height: 2rem;
+  border-radius: 999px;
+  color: var(--gcve-nav-subtle);
+  font-size: 0.86rem;
+  font-weight: 700;
+  line-height: 1;
+  text-decoration: none !important;
+  transition: color 0.18s ease, background-color 0.18s ease, box-shadow 0.18s ease, transform 0.18s ease;
+}
+
+.gcve-nav-link {
+  padding: 0.45rem 0.78rem;
+}
+
+.gcve-icon-link {
+  min-width: 2rem;
+  padding: 0.45rem;
+}
+
+.gcve-database-link {
+  padding-inline: 0.7rem;
+}
+
+.gcve-nav-link:hover,
+.gcve-icon-link:hover,
+.gcve-nav-link.is-active {
+  color: var(--gcve-nav-text);
+  background: var(--gcve-nav-surface-strong);
+  box-shadow: 0 8px 22px rgba(16, 35, 63, 0.08);
+  transform: translateY(-1px);
+}
+
+.dark .gcve-nav-link:hover,
+.dark .gcve-icon-link:hover,
+.dark .gcve-nav-link.is-active {
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.24);
+}
+
+.gcve-nav-link.is-active {
+  color: #174bd6;
+}
+
+.dark .gcve-nav-link.is-active {
+  color: #8be9f7;
+}
+
+.gcve-nav-tools .search-wrapper {
+  width: clamp(11rem, 18vw, 15rem);
+}
+
+.gcve-nav-tools .search-input {
+  border: 1px solid rgba(38, 100, 255, 0.11);
+  border-radius: 999px;
+  background: var(--gcve-nav-surface);
+  font-weight: 600;
+}
+
+.dark .gcve-nav-tools .search-input {
+  border-color: rgba(255, 255, 255, 0.08);
+}
+
+@media (max-width: 1180px) {
+  .gcve-brand-subtitle {
+    display: none;
+  }
+}
+
 .content :is(h1, h2, h3) {
   letter-spacing: -0.035em;
 }
@@ -324,5 +478,39 @@ body {
 
   .gcve-hero h1 {
     max-width: 100%;
+  }
+}
+
+@media (max-width: 1100px) {
+  .gcve-nav-tools .search-wrapper {
+    display: none;
+  }
+
+  .gcve-database-link span {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  .gcve-database-link {
+    min-width: 2rem;
+    padding-inline: 0.45rem;
+  }
+}
+
+@media (max-width: 860px) {
+  .gcve-nav-link {
+    padding-inline: 0.58rem;
+    font-size: 0.8rem;
+  }
+
+  .gcve-nav-tools {
+    display: none !important;
   }
 }

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -1,0 +1,96 @@
+{{- $logoPath := .Site.Params.navbar.logo.path | default "images/logo.svg" -}}
+{{- $logoLink := .Site.Params.navbar.logo.link | default .Site.Home.RelPermalink -}}
+{{- $logoWidth := .Site.Params.navbar.logo.width | default "34" -}}
+{{- $logoHeight := .Site.Params.navbar.logo.height | default "34" -}}
+{{- $logoDarkPath := .Site.Params.navbar.logo.dark | default $logoPath -}}
+
+{{- $navWidth := "hx-max-w-[90rem]" -}}
+{{- with .Site.Params.navbar.width -}}
+  {{ if eq . "normal" -}}
+    {{ $navWidth = "hx-max-w-screen-xl" -}}
+  {{ else if eq . "full" -}}
+    {{ $navWidth = "max-w-full" -}}
+  {{ end -}}
+{{- end -}}
+
+<div class="nav-container hx-sticky hx-top-0 hx-z-20 hx-w-full hx-bg-transparent print:hx-hidden">
+  <div class="nav-container-blur hx-pointer-events-none hx-absolute hx-z-[-1] hx-h-full hx-w-full hx-bg-white dark:hx-bg-dark hx-shadow-[0_2px_4px_rgba(0,0,0,.02),0_1px_0_rgba(0,0,0,.06)] contrast-more:hx-shadow-[0_0_0_1px_#000] dark:hx-shadow-[0_-1px_0_rgba(255,255,255,.1)_inset] contrast-more:dark:hx-shadow-[0_0_0_1px_#fff]"></div>
+
+  <nav class="gcve-navbar hx-mx-auto hx-flex hx-items-center hx-gap-3 hx-h-16 hx-px-6 {{ $navWidth }}">
+    <a class="gcve-brand hx-flex hx-items-center hx-gap-3 hover:hx-opacity-90 ltr:hx-mr-auto rtl:hx-ml-auto" href="{{ $logoLink }}" aria-label="{{ .Site.Title }}">
+      {{- if (.Site.Params.navbar.displayLogo | default true) }}
+        <span class="gcve-brand-mark" aria-hidden="true">
+          <img class="hx-block dark:hx-hidden" src="{{ $logoPath | relURL }}" alt="" height="{{ $logoHeight }}" width="{{ $logoWidth }}" />
+          <img class="hx-hidden dark:hx-block" src="{{ $logoDarkPath | relURL }}" alt="" height="{{ $logoHeight }}" width="{{ $logoWidth }}" />
+        </span>
+      {{- end }}
+      {{- if (.Site.Params.navbar.displayTitle | default true) }}
+        <span class="gcve-brand-copy" title="{{ .Site.Title }}">
+          <span class="gcve-brand-title">GCVE</span>
+          <span class="gcve-brand-subtitle">Global CVE Allocation System</span>
+        </span>
+      {{- end }}
+    </a>
+
+    {{- $currentPage := . -}}
+    <div class="gcve-nav-links hx-hidden md:hx-flex hx-items-center hx-gap-1" aria-label="Primary navigation">
+      {{- range .Site.Menus.main -}}
+        {{- if and (ne .Params.type "search") (not .Params.icon) -}}
+        {{- $link := .URL -}}
+        {{- $external := strings.HasPrefix $link "http" -}}
+        {{- with .PageRef -}}
+          {{- if hasPrefix . "/" -}}
+            {{- $link = relLangURL (strings.TrimPrefix "/" .) -}}
+          {{- end -}}
+        {{- end -}}
+        {{- $active := or ($currentPage.HasMenuCurrent "main" .) ($currentPage.IsMenuCurrent "main" .) -}}
+        <a
+          title="{{ or (T .Identifier) .Name | safeHTML }}"
+          href="{{ $link }}"
+          {{ if $external }}target="_blank" rel="noreferrer"{{ end }}
+          class="gcve-nav-link{{ if $active }} is-active{{ end }}"
+          {{ if $active }}aria-current="page"{{ end }}
+        >
+          {{ or (T .Identifier) .Name | safeHTML }}
+        </a>
+        {{- end -}}
+      {{- end -}}
+    </div>
+
+    <div class="gcve-nav-tools hx-hidden md:hx-flex hx-items-center hx-gap-2">
+      {{- range .Site.Menus.main -}}
+        {{- if eq .Params.type "search" -}}
+          {{- partial "search.html" (dict "params" .Params) -}}
+        {{- end -}}
+      {{- end -}}
+
+      <div class="gcve-icon-links hx-flex hx-items-center hx-gap-1" aria-label="GCVE external resources">
+        {{- range .Site.Menus.main -}}
+          {{- if .Params.icon -}}
+            {{- $link := .URL -}}
+            {{- $external := strings.HasPrefix $link "http" -}}
+            {{- with .PageRef -}}
+              {{- if hasPrefix . "/" -}}
+                {{- $link = relLangURL (strings.TrimPrefix "/" .) -}}
+              {{- end -}}
+            {{- end -}}
+            {{- $rel := cond (eq .Params.icon "mastodon") "noreferrer me" "noreferrer" -}}
+            {{- $label := or (T .Identifier) .Name | safeHTML -}}
+            <a class="gcve-icon-link{{ if eq .Params.icon "database" }} gcve-database-link{{ end }}" {{ if $external }}target="_blank" rel="{{ $rel }}"{{ end }} href="{{ $link }}" title="{{ $label }}">
+              {{- partial "utils/icon.html" (dict "name" .Params.icon "attributes" "height=18") -}}
+              {{- if eq .Params.icon "database" -}}
+                <span>{{ $label }}</span>
+              {{- else -}}
+                <span class="hx-sr-only">{{ $label }}</span>
+              {{- end -}}
+            </a>
+          {{- end -}}
+        {{- end -}}
+      </div>
+    </div>
+
+    <button type="button" aria-label="Menu" class="hamburger-menu -hx-mr-2 hx-rounded-xl hx-p-2 active:hx-bg-gray-400/20 md:hx-hidden">
+      {{- partial "utils/icon.html" (dict "name" "hamburger-menu" "attributes" "height=24") -}}
+    </button>
+  </nav>
+</div>


### PR DESCRIPTION
### Motivation
- Improve the top header/menu readability and professional appearance and align it with the GCVE visual style. 
- Separate primary navigation from utility/external links so items are easier to scan and use. 
- Ensure accessible labels and responsive behavior so the header stays usable across viewport sizes.

### Description
- Add a GCVE-specific navbar partial at `layouts/partials/navbar.html` that shortens the brand text, shows a compact logo mark, groups primary links, and exposes external resource icons with accessible titles. 
- Extend `assets/css/custom.css` with a new `.gcve-navbar` rule set that implements pill-style link groups, elevated logo mark, hover/active states, dark-mode variables, and spacing tweaks to match site branding. 
- Add responsive tweaks to hide the subtitle/search at narrower widths and simplify tool links; adjust hamburger/menu breakpoints to ensure consistent mobile behavior.

### Testing
- `git diff --check` was run and returned no problems. 
- Attempted to run a Hugo build (`hugo --gc --minify`) but the Hugo binary is not available in the environment so a full site build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2527f79e388324bd624942c436fa7a)