### PR TITLE
Improve hamburger menu visibility and tablet behaviour

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -191,6 +191,119 @@ body {
   border-color: rgba(255, 255, 255, 0.08);
 }
 
+.hamburger-menu {
+  display: inline-flex !important;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 2.75rem;
+  height: 2.75rem;
+  border: 1px solid rgba(38, 100, 255, 0.28);
+  border-radius: 0.95rem;
+  color: #113f9f;
+  background:
+    radial-gradient(circle at 72% 22%, rgba(34, 195, 223, 0.32), transparent 54%),
+    rgba(255, 255, 255, 0.96);
+  box-shadow: 0 12px 30px rgba(16, 35, 63, 0.16), inset 0 1px 0 rgba(255, 255, 255, 0.72);
+  transition: color 0.18s ease, background-color 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease, transform 0.18s ease;
+}
+
+.hamburger-menu svg {
+  width: 1.55rem;
+  height: 1.55rem;
+  stroke-width: 2.35;
+  filter: drop-shadow(0 1px 0 rgba(255, 255, 255, 0.6));
+}
+
+.hamburger-menu:hover,
+.hamburger-menu:focus-visible,
+.hamburger-menu.gcve-menu-open {
+  color: #ffffff;
+  border-color: rgba(23, 75, 214, 0.72);
+  background: linear-gradient(135deg, #174bd6, #22c3df);
+  box-shadow: 0 14px 34px rgba(38, 100, 255, 0.28);
+  transform: translateY(-1px);
+}
+
+.hamburger-menu:focus-visible {
+  outline: 3px solid rgba(34, 195, 223, 0.34);
+  outline-offset: 3px;
+}
+
+.dark .hamburger-menu {
+  border-color: rgba(34, 195, 223, 0.36);
+  color: #e8f1fb;
+  background:
+    radial-gradient(circle at 72% 22%, rgba(34, 195, 223, 0.26), transparent 54%),
+    rgba(18, 24, 38, 0.96);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.34), inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.dark .hamburger-menu:hover,
+.dark .hamburger-menu:focus-visible,
+.dark .hamburger-menu.gcve-menu-open {
+  color: #07111f;
+  border-color: rgba(139, 233, 247, 0.78);
+  background: linear-gradient(135deg, #8be9f7, #94d82d);
+  box-shadow: 0 14px 34px rgba(34, 195, 223, 0.22);
+}
+
+@media (min-width: 1025px) {
+  .hamburger-menu {
+    display: none !important;
+  }
+}
+
+@media (max-width: 1024px) {
+  .gcve-nav-links,
+  .gcve-nav-tools {
+    display: none !important;
+  }
+
+  .sidebar-container {
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    z-index: 15;
+    width: min(100%, 26rem);
+    padding-top: var(--navbar-height);
+    background: #ffffff;
+    overscroll-behavior: contain;
+    transform: translate3d(0, -100%, 0);
+    transition: transform 0.8s cubic-bezier(0.52, 0.16, 0.04, 1);
+    will-change: transform, opacity;
+    contain: layout style;
+    backface-visibility: hidden;
+  }
+
+  .dark .sidebar-container {
+    background: #111111;
+  }
+
+  .sidebar-container.gcve-menu-open {
+    transform: translate3d(0, 0, 0);
+  }
+
+  body.gcve-menu-open {
+    overflow: hidden !important;
+  }
+}
+
+@media (min-width: 768px) and (max-width: 1024px) {
+  .sidebar-container > .hx-px-4,
+  .sidebar-container .hextra-scrollbar > ul:first-child {
+    display: flex !important;
+  }
+
+  .sidebar-container > .hx-px-4 {
+    flex-direction: column;
+  }
+
+  .sidebar-container .hextra-scrollbar > ul:not(:first-child) {
+    display: none !important;
+  }
+}
+
 @media (max-width: 1180px) {
   .gcve-brand-subtitle {
     display: none;

--- a/assets/js/menu.js
+++ b/assets/js/menu.js
@@ -1,0 +1,56 @@
+// Hamburger menu for mobile navigation
+
+document.addEventListener('DOMContentLoaded', function () {
+  const menu = document.querySelector('.hamburger-menu');
+  const overlay = document.querySelector('.mobile-menu-overlay');
+  const sidebarContainer = document.querySelector('.sidebar-container');
+
+  if (!menu || !overlay || !sidebarContainer) return;
+
+  // Initialize the overlay
+  const overlayClasses = ['hx-fixed', 'hx-inset-0', 'hx-z-10', 'hx-bg-black/80', 'dark:hx-bg-black/60'];
+  overlay.classList.add('hx-bg-transparent');
+  overlay.classList.remove("hx-hidden", ...overlayClasses);
+
+  function toggleMenu() {
+    // Toggle the hamburger menu
+    menu.classList.toggle('gcve-menu-open');
+    menu.querySelector('svg').classList.toggle('open');
+
+    // When the menu is open, we want to show the navigation sidebar.
+    // Keep the original Hextra transform classes for phones, and add a
+    // project class so the same menu can be opened on tablet-sized screens.
+    sidebarContainer.classList.toggle('gcve-menu-open');
+    sidebarContainer.classList.toggle('max-md:[transform:translate3d(0,-100%,0)]');
+    sidebarContainer.classList.toggle('max-md:[transform:translate3d(0,0,0)]');
+
+    // When the menu is open, we want to prevent the body from scrolling
+    document.body.classList.toggle('gcve-menu-open');
+    document.body.classList.toggle('hx-overflow-hidden');
+    document.body.classList.toggle('md:hx-overflow-auto');
+  }
+
+  menu.addEventListener('click', (e) => {
+    e.preventDefault();
+    toggleMenu();
+
+    if (overlay.classList.contains('hx-bg-transparent')) {
+      // Show the overlay
+      overlay.classList.add(...overlayClasses);
+      overlay.classList.remove('hx-bg-transparent');
+    } else {
+      // Hide the overlay
+      overlay.classList.remove(...overlayClasses);
+      overlay.classList.add('hx-bg-transparent');
+    }
+  });
+
+  overlay.addEventListener('click', (e) => {
+    e.preventDefault();
+    toggleMenu();
+
+    // Hide the overlay
+    overlay.classList.remove(...overlayClasses);
+    overlay.classList.add('hx-bg-transparent');
+  });
+});


### PR DESCRIPTION
### Motivation
- The hamburger ("burger") button was difficult to spot on larger and some small screens and the primary nav became crowded on tablet sizes, so the menu needed stronger visual affordance and the mobile menu to be usable on tablets.
- The change aims to make the menu button more visible, provide clear hover/focus/open states (including dark mode), and allow the sidebar to open for a wider range of screen sizes.

### Description
- Add a full set of project styles for `.hamburger-menu` (size, border, background, shadow, hover/focus/open states and dark-mode variants) and enlarge its hit area. (`assets/css/custom.css`).
- Change responsive rules so the hamburger is used up to `1024px` and hide the crowded `.gcve-nav-links` / `.gcve-nav-tools` in that range. (`assets/css/custom.css`).
- Add styles to animate and position the sidebar for tablet/phone (`.sidebar-container.gcve-menu-open`) and prevent page scrolling while open (`body.gcve-menu-open`). (`assets/css/custom.css`).
- Add a project-level menu script override that toggles `gcve-menu-open` on the button, sidebar and `body`, preserves original Hextra transform toggles for phones, and guards against missing elements. (`assets/js/menu.js`).

### Testing
- Ran `git diff --check -- assets/css/custom.css assets/js/menu.js` with no issues reported. (passed)
- Ran `node --check assets/js/menu.js` to validate the new script syntax. (passed)
- Attempted `hugo --minify` but could not run because `hugo` is not installed in the environment. (not executed)
- Attempted to install Hugo via `go install github.com/gohugoio/hugo@v0.147.9` but the fetch failed due to Go proxy restrictions. (not executed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2529a677b483249eac63829c5ffbc2)