### PR TITLE
Keep hamburger menu visible on large screens

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -248,12 +248,6 @@ body {
   box-shadow: 0 14px 34px rgba(34, 195, 223, 0.22);
 }
 
-@media (min-width: 1025px) {
-  .hamburger-menu {
-    display: none !important;
-  }
-}
-
 @media (max-width: 1024px) {
   .gcve-nav-links,
   .gcve-nav-tools {

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -89,7 +89,7 @@
       </div>
     </div>
 
-    <button type="button" aria-label="Menu" class="hamburger-menu -hx-mr-2 hx-rounded-xl hx-p-2 active:hx-bg-gray-400/20 md:hx-hidden">
+    <button type="button" aria-label="Menu" class="hamburger-menu -hx-mr-2 hx-rounded-xl hx-p-2 active:hx-bg-gray-400/20">
       {{- partial "utils/icon.html" (dict "name" "hamburger-menu" "attributes" "height=24") -}}
     </button>
   </nav>


### PR DESCRIPTION
### Motivation
- The hamburger menu button was being hidden at large/desktop breakpoints which prevented users from opening the mobile-style navigation on wider screens, so the menu should remain available across viewports.

### Description
- Removed the `md:hx-hidden` responsive hide utility from the hamburger button in `layouts/partials/navbar.html` and removed the `@media (min-width: 1025px)` rule that forced `.hamburger-menu { display: none !important; }` from `assets/css/custom.css` so the `.hamburger-menu` styles apply on large screens.

### Testing
- Ran `git diff --check` which reported no issues.
- Attempted to run `hugo` but it could not be executed in this environment because the Hugo binary is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a252b39bec8832481748a55438728d1)