### PR TITLE
Fix hamburger menu on large screens

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -259,6 +259,7 @@ body {
     top: 0;
     bottom: 0;
     z-index: 15;
+    inset-inline-start: 0;
     width: min(100%, 26rem);
     padding-top: var(--navbar-height);
     background: #ffffff;
@@ -283,17 +284,45 @@ body {
   }
 }
 
-@media (min-width: 768px) and (max-width: 1024px) {
-  .sidebar-container > .hx-px-4,
-  .sidebar-container .hextra-scrollbar > ul:first-child {
+@media (min-width: 1025px) {
+  .sidebar-container.gcve-menu-open {
+    position: fixed !important;
+    top: 0;
+    bottom: 0;
+    z-index: 15;
+    inset-inline-start: 0;
+    display: flex !important;
+    width: min(100%, 26rem) !important;
+    padding-top: var(--navbar-height);
+    background: #ffffff;
+    overscroll-behavior: contain;
+    transform: translate3d(0, 0, 0);
+    transition: transform 0.8s cubic-bezier(0.52, 0.16, 0.04, 1);
+    will-change: transform, opacity;
+    contain: layout style;
+    backface-visibility: hidden;
+  }
+
+  .dark .sidebar-container.gcve-menu-open {
+    background: #111111;
+  }
+
+  body.gcve-menu-open {
+    overflow: hidden !important;
+  }
+}
+
+@media (min-width: 768px) {
+  .sidebar-container.gcve-menu-open > .hx-px-4,
+  .sidebar-container.gcve-menu-open .hextra-scrollbar > ul:first-child {
     display: flex !important;
   }
 
-  .sidebar-container > .hx-px-4 {
+  .sidebar-container.gcve-menu-open > .hx-px-4 {
     flex-direction: column;
   }
 
-  .sidebar-container .hextra-scrollbar > ul:not(:first-child) {
+  .sidebar-container.gcve-menu-open .hextra-scrollbar > ul:not(:first-child) {
     display: none !important;
   }
 }

--- a/assets/js/menu.js
+++ b/assets/js/menu.js
@@ -12,22 +12,27 @@ document.addEventListener('DOMContentLoaded', function () {
   overlay.classList.add('hx-bg-transparent');
   overlay.classList.remove("hx-hidden", ...overlayClasses);
 
-  function toggleMenu() {
+  function setMenuOpen(open) {
     // Toggle the hamburger menu
-    menu.classList.toggle('gcve-menu-open');
-    menu.querySelector('svg').classList.toggle('open');
+    menu.classList.toggle('gcve-menu-open', open);
+    menu.setAttribute('aria-expanded', String(open));
+    menu.querySelector('svg').classList.toggle('open', open);
 
     // When the menu is open, we want to show the navigation sidebar.
     // Keep the original Hextra transform classes for phones, and add a
     // project class so the same menu can be opened on tablet-sized screens.
-    sidebarContainer.classList.toggle('gcve-menu-open');
-    sidebarContainer.classList.toggle('max-md:[transform:translate3d(0,-100%,0)]');
-    sidebarContainer.classList.toggle('max-md:[transform:translate3d(0,0,0)]');
+    sidebarContainer.classList.toggle('gcve-menu-open', open);
+    sidebarContainer.classList.toggle('max-md:[transform:translate3d(0,-100%,0)]', !open);
+    sidebarContainer.classList.toggle('max-md:[transform:translate3d(0,0,0)]', open);
 
     // When the menu is open, we want to prevent the body from scrolling
-    document.body.classList.toggle('gcve-menu-open');
-    document.body.classList.toggle('hx-overflow-hidden');
-    document.body.classList.toggle('md:hx-overflow-auto');
+    document.body.classList.toggle('gcve-menu-open', open);
+    document.body.classList.toggle('hx-overflow-hidden', open);
+    document.body.classList.toggle('md:hx-overflow-auto', open);
+  }
+
+  function toggleMenu() {
+    setMenuOpen(!menu.classList.contains('gcve-menu-open'));
   }
 
   menu.addEventListener('click', (e) => {
@@ -47,7 +52,7 @@ document.addEventListener('DOMContentLoaded', function () {
 
   overlay.addEventListener('click', (e) => {
     e.preventDefault();
-    toggleMenu();
+    setMenuOpen(false);
 
     // Hide the overlay
     overlay.classList.remove(...overlayClasses);

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -89,7 +89,7 @@
       </div>
     </div>
 
-    <button type="button" aria-label="Menu" class="hamburger-menu -hx-mr-2 hx-rounded-xl hx-p-2 active:hx-bg-gray-400/20">
+    <button type="button" aria-label="Menu" aria-expanded="false" class="hamburger-menu -hx-mr-2 hx-rounded-xl hx-p-2 active:hx-bg-gray-400/20">
       {{- partial "utils/icon.html" (dict "name" "hamburger-menu" "attributes" "height=24") -}}
     </button>
   </nav>


### PR DESCRIPTION
### Motivation
- The hamburger drawer was only visible on small screens and remained hidden on larger viewports when opened, causing the menu to be inaccessible on tablet/desktop sizes.
- The toggle behavior was class-toggle based and did not reliably synchronize visual state, DOM attributes, or scroll-lock across breakpoints.

### Description
- Implemented a state-driven API in `assets/js/menu.js` by adding `setMenuOpen(open)` and a `toggleMenu()` wrapper so open/closed state is explicit and `aria-expanded` is synchronized on the button.
- Updated overlay handling to call `setMenuOpen(false)` when the overlay is clicked and to keep the overlay classes consistent when showing/hiding the overlay.
- Added large-screen open-state CSS in `assets/css/custom.css` that targets `.sidebar-container.gcve-menu-open` for `@media (min-width: 1025px)` so the drawer becomes fixed, left-aligned (`inset-inline-start: 0`), visible and scroll-locked above the previous 1024px breakpoint, and scoped desktop/tablet content overrides to the open state (`.sidebar-container.gcve-menu-open`).
- Added initial `aria-expanded="false"` to the hamburger button in `layouts/partials/navbar.html` for correct a11y baseline.

### Testing
- Run-time check: `node --check assets/js/menu.js` succeeded.
- Repo checks: `git diff --check` produced no issues.
- Site build: attempted `hugo --minify` but it could not be run because `hugo` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a252c1ff07c8324884e7d01c5cd911e)