### PR TITLE
Revamp /software page layout and add cpe-editor & AI annotation tool

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -650,3 +650,185 @@ body {
     display: none !important;
   }
 }
+
+.gcve-software-hero .gcve-hero h1,
+.gcve-software-hero h1 {
+  max-width: 12ch;
+}
+
+.gcve-software-panel-header {
+  display: grid;
+  gap: 0.75rem;
+  justify-items: center;
+  margin-bottom: 1rem;
+  text-align: center;
+}
+
+.gcve-software-panel-header img {
+  width: min(100%, 220px);
+  margin: 0;
+}
+
+.gcve-software-panel-header p {
+  max-width: 22rem;
+  margin: 0;
+  color: var(--gcve-muted);
+  font-size: 0.96rem;
+  line-height: 1.55;
+}
+
+.gcve-software-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1.15rem;
+  margin: 1.35rem 0 2.75rem;
+}
+
+.gcve-software-grid-featured {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.gcve-tool-card {
+  position: relative;
+  isolation: isolate;
+  display: grid;
+  grid-template-columns: minmax(7rem, 0.32fr) minmax(0, 1fr);
+  gap: 1.15rem;
+  overflow: hidden;
+  padding: 1.2rem;
+  border: 1px solid var(--gcve-border);
+  border-radius: 1.35rem;
+  background: var(--gcve-card);
+  box-shadow: 0 16px 38px rgba(16, 35, 63, 0.07);
+  backdrop-filter: blur(14px);
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.gcve-tool-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  border-radius: inherit;
+  background: linear-gradient(135deg, rgba(38, 100, 255, 0.11), rgba(34, 195, 223, 0.08), transparent 58%);
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.gcve-tool-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(34, 195, 223, 0.42);
+  box-shadow: 0 24px 54px rgba(16, 35, 63, 0.13);
+}
+
+.gcve-tool-card:hover::before {
+  opacity: 1;
+}
+
+.gcve-tool-card-featured {
+  grid-template-columns: minmax(13rem, 0.38fr) minmax(0, 1fr);
+  padding: clamp(1.2rem, 3vw, 1.7rem);
+}
+
+.gcve-tool-card-media {
+  display: grid;
+  align-self: start;
+  place-items: center;
+  min-height: 8rem;
+  padding: 1rem;
+  border: 1px solid rgba(38, 100, 255, 0.11);
+  border-radius: 1.1rem;
+  background: rgba(255, 255, 255, 0.58);
+}
+
+.dark .gcve-tool-card-media {
+  border-color: rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.gcve-tool-card-media img {
+  max-width: min(100%, 13rem);
+  max-height: 7rem;
+  object-fit: contain;
+}
+
+.gcve-tool-card-media-wide img {
+  max-width: min(100%, 18rem);
+}
+
+.gcve-tool-card-body {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.gcve-tool-kicker {
+  margin: 0 0 0.45rem;
+  color: #0b7285;
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.dark .gcve-tool-kicker {
+  color: #8be9f7;
+}
+
+.gcve-tool-card h3 {
+  margin: 0;
+  color: var(--gcve-ink);
+  font-size: clamp(1.35rem, 2vw, 1.8rem);
+  line-height: 1.08;
+  letter-spacing: -0.05em;
+}
+
+.gcve-tool-card p:not(.gcve-tool-kicker) {
+  margin: 0.85rem 0 0;
+  color: var(--gcve-muted);
+  line-height: 1.65;
+}
+
+.gcve-tool-list {
+  display: grid;
+  gap: 0.45rem;
+  margin: 1rem 0 0;
+  padding-left: 1.15rem;
+  color: var(--gcve-muted);
+  line-height: 1.5;
+}
+
+.gcve-tool-list li::marker {
+  color: var(--gcve-cyan);
+}
+
+.gcve-tool-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+  margin-top: auto;
+  padding-top: 1.25rem;
+}
+
+.gcve-tool-actions .gcve-button {
+  min-height: 2.55rem;
+  padding: 0.62rem 0.9rem;
+  font-size: 0.92rem;
+}
+
+@media (max-width: 1180px) {
+  .gcve-software-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+@media (max-width: 720px) {
+  .gcve-tool-card,
+  .gcve-tool-card-featured {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .gcve-tool-card-media {
+    min-height: 6rem;
+  }
+}

--- a/content/software.md
+++ b/content/software.md
@@ -1,68 +1,160 @@
 ---
 title: GCVE - Software
+toc: false
 ---
 
-[GCVE BCP](/bcp) defines different standards that are implemented in open-source software to support GCVE publication processes and operations.
+<section class="gcve-hero gcve-software-hero">
+  <div class="gcve-hero-grid">
+    <div>
+      <p class="gcve-eyebrow">Open-source GCVE ecosystem</p>
+      <h1>Software for <span class="gcve-gradient-text">GCVE</span></h1>
+      <p class="gcve-hero-lede">Tools, libraries, validators, and integrations that implement GCVE Best Current Practices and help teams publish, curate, enrich, and consume vulnerability information.</p>
+      <div class="gcve-hero-actions">
+        <a class="gcve-button gcve-button-primary" href="#reference-implementation">Reference implementation</a>
+        <a class="gcve-button gcve-button-secondary" href="#supporting-tools">Supporting tools</a>
+      </div>
+    </div>
+    <div class="gcve-hero-panel gcve-software-panel" aria-label="Software focus areas">
+      <div class="gcve-software-panel-header">
+        <img src="/logos/gcve.png" alt="GCVE logo" />
+        <p>BCP-aligned building blocks for distributed vulnerability publication.</p>
+      </div>
+      <div class="gcve-stat-grid">
+        <div class="gcve-stat"><strong>GNA</strong><span>Operate numbering workflows</span></div>
+        <div class="gcve-stat"><strong>CPE</strong><span>Curate product metadata</span></div>
+        <div class="gcve-stat"><strong>KEV</strong><span>Publish exploitation assertions</span></div>
+        <div class="gcve-stat"><strong>AI</strong><span>Annotate assisted enrichment</span></div>
+      </div>
+    </div>
+  </div>
+</section>
 
-# Software
+[GCVE BCP](/bcp) defines standards implemented in open-source software to support GCVE publication processes and operations. The projects below are organized around the same polished, card-based style as the main page so implementers can quickly find production platforms, curation tools, validators, and integration helpers.
 
-## Reference Software Implementation of the GCVE Standard
+<h2 id="reference-implementation">Reference Software Implementation of the GCVE Standard</h2>
 
-{{< cards >}}
-  {{< card link="about" title="vulnerability-lookup" image="https://vulnerability.circl.lu/static/img/VL-hori-coul.png" link="https://www.vulnerability-lookup.org/" >}}
-{{< /cards >}}
+<p class="gcve-section-intro">Start here if you want a complete open-source platform for vulnerability publication and GCVE Numbering Authority operations.</p>
 
-The Vulnerability-Lookup software is a powerful open-source sharing platform that assists security teams, researchers, and system administrators in identifying, tracking, and publishing vulnerabilities. Vulnerability-Lookup implements all the required [GCVE BCP](/bcp) standards to operate a GNA.
+<div class="gcve-software-grid gcve-software-grid-featured">
+  <article class="gcve-tool-card gcve-tool-card-featured">
+    <div class="gcve-tool-card-media gcve-tool-card-media-wide">
+      <img src="https://vulnerability.circl.lu/static/img/VL-hori-coul.png" alt="Vulnerability-Lookup logo" />
+    </div>
+    <div class="gcve-tool-card-body">
+      <p class="gcve-tool-kicker">Reference implementation</p>
+      <h3>vulnerability-lookup</h3>
+      <p>The Vulnerability-Lookup software is a powerful open-source sharing platform that assists security teams, researchers, and system administrators in identifying, tracking, and publishing vulnerabilities. Vulnerability-Lookup implements the required GCVE BCP standards to operate a GNA.</p>
+      <ul class="gcve-tool-list">
+        <li>GCVE-compatible vulnerability publication workflows.</li>
+        <li>Designed for vulnerability intelligence sharing and lookup.</li>
+        <li>Suitable as a complete GNA operational platform.</li>
+      </ul>
+      <div class="gcve-tool-actions">
+        <a class="gcve-button gcve-button-primary" href="https://www.vulnerability-lookup.org/">Open project</a>
+        <a class="gcve-button gcve-button-secondary" href="https://github.com/vulnerability-lookup/vulnerability-lookup">GitHub repository</a>
+      </div>
+    </div>
+  </article>
+</div>
 
-{{% details title="Details" %}}
-- {{< icon "github" >}} [https://github.com/vulnerability-lookup/vulnerability-lookup](https://github.com/vulnerability-lookup/vulnerability-lookup)
-{{% /details %}}
+<h2 id="supporting-tools">Software Supporting the GCVE BCP Standards</h2>
 
-## Software Supporting the GCVE BCP Standards
+<p class="gcve-section-intro">Composable tools for curation, validation, conversion, AI provenance, and client-side integration across GCVE-compatible systems.</p>
 
-### BCP-07 Known Exploited Vulnerability (KEV)
+<div class="gcve-software-grid">
+  <article class="gcve-tool-card">
+    <div class="gcve-tool-card-media">
+      <img src="/logos/gcve.png" alt="GCVE logo" />
+    </div>
+    <div class="gcve-tool-card-body">
+      <p class="gcve-tool-kicker">CPE and product curation</p>
+      <h3>cpe-editor</h3>
+      <p>A collaborative CPE editor for browsing, curating, and publishing Common Platform Enumeration data with moderation workflows, API access, and portable datasets.</p>
+      <ul class="gcve-tool-list">
+        <li>Browse vendors, products, CPE records, and relationships.</li>
+        <li>Review structured public proposals through moderation workflows.</li>
+        <li>Import NVD, PURL-to-CPE, and GCVE enriched CVE data.</li>
+      </ul>
+      <div class="gcve-tool-actions">
+        <a class="gcve-button gcve-button-primary" href="https://cpe.gcve.eu/">Open service</a>
+        <a class="gcve-button gcve-button-secondary" href="https://github.com/gcve-eu/cpe-editor">GitHub repository</a>
+      </div>
+    </div>
+  </article>
 
-{{< cards >}}
-  {{< card link="about" title="gcve-eu-kev" subtitle="GCVE-BCP-07 Known Exploited Vulnerability (KEV) conversion tool." link="https://github.com/gcve-eu/gcve-eu-kev" image="https://gcve.eu/logos/gcve.png">}}
-{{< /cards >}}
+  <article class="gcve-tool-card">
+    <div class="gcve-tool-card-media">
+      <img src="/logos/gcve.png" alt="GCVE logo" />
+    </div>
+    <div class="gcve-tool-card-body">
+      <p class="gcve-tool-kicker">AI-assisted annotation</p>
+      <h3>AI-Assisted Vulnerability Information Annotation</h3>
+      <p>A Python utility that fetches vulnerability records from db.gcve.eu, generates analyst-oriented summaries and recommendations with a configurable local Ollama model, and records GCVE AI provenance metadata.</p>
+      <ul class="gcve-tool-list">
+        <li>Accepts CVE IDs and GCVE IDs from db.gcve.eu.</li>
+        <li>Adds local AI enrichment and BCP-05-X-01 provenance annotations.</li>
+        <li>Outputs enriched JSON for review and downstream processing.</li>
+      </ul>
+      <div class="gcve-tool-actions">
+        <a class="gcve-button gcve-button-primary" href="https://github.com/gcve-eu/gcve-eu-ai-extension">GitHub repository</a>
+      </div>
+    </div>
+  </article>
 
-Python script that downloads the CISA Known Exploited Vulnerabilities (KEV) Catalog/ENISA CNW EUVD KEV (CSV) and converts each entry into a GCVE-BCP-07 Known Exploited Vulnerability (KEV) Assertion JSON object.
+  <article class="gcve-tool-card">
+    <div class="gcve-tool-card-media">
+      <img src="/logos/gcve.png" alt="GCVE logo" />
+    </div>
+    <div class="gcve-tool-card-body">
+      <p class="gcve-tool-kicker">BCP-07 KEV assertions</p>
+      <h3>gcve-eu-kev</h3>
+      <p>Python tooling that downloads Known Exploited Vulnerability feeds and converts entries into GCVE-BCP-07 KEV Assertion JSON objects.</p>
+      <ul class="gcve-tool-list">
+        <li>Transforms list-based KEV feeds into attributable assertions.</li>
+        <li>Supports ingestion into GCVE-compatible systems and pipelines.</li>
+        <li>Helps operational teams preserve structured exploitation context.</li>
+      </ul>
+      <div class="gcve-tool-actions">
+        <a class="gcve-button gcve-button-primary" href="https://github.com/gcve-eu/gcve-eu-kev">GitHub repository</a>
+      </div>
+    </div>
+  </article>
 
-The goal is to transform a list-based KEV feed into attributable, structured exploitation assertions suitable for ingestion into GCVE-compatible systems, vulnerability databases, or analytical pipelines.
+  <article class="gcve-tool-card">
+    <div class="gcve-tool-card-media">
+      <img src="/logos/gcve.png" alt="GCVE logo" />
+    </div>
+    <div class="gcve-tool-card-body">
+      <p class="gcve-tool-kicker">Schemas and validation</p>
+      <h3>bcp-validator</h3>
+      <p>Validators and JSON Schemas for GCVE Best Current Practices, built to help producers, consumers, and integrators validate GCVE-related data structures consistently.</p>
+      <ul class="gcve-tool-list">
+        <li>Implementation-oriented validation for BCP data structures.</li>
+        <li>Reusable JSON Schemas for automated checks.</li>
+        <li>Interoperability support for GCVE producers and consumers.</li>
+      </ul>
+      <div class="gcve-tool-actions">
+        <a class="gcve-button gcve-button-primary" href="https://github.com/gcve-eu/bcp-validator">GitHub repository</a>
+      </div>
+    </div>
+  </article>
 
-{{% details title="Details" %}}
-- {{< icon "github" >}} [https://github.com/gcve-eu/gcve-eu-kev](https://github.com/gcve-eu/gcve-eu-kev)
-{{% /details %}}
-
-### GCVE BCP Validators and Schemas
-
-{{< cards >}}
-  {{< card link="about" title="bcp-validator" subtitle="Validators and JSON Schemas for GCVE Best Current Practices (BCPs)." link="https://github.com/gcve-eu/bcp-validator" image="https://gcve.eu/logos/gcve.png">}}
-{{< /cards >}}
-
-This repository contains validators and JSON Schemas for GCVE Best Current Practices (BCPs).
-
-Its goal is to provide practical, implementation-oriented tooling to help producers, consumers, and integrators validate GCVE-related data structures in a consistent and interoperable way.
-
-{{% details title="Details" %}}
-- {{< icon "github" >}} [https://github.com/gcve-eu/bcp-validator](https://github.com/gcve-eu/bcp-validator)
-{{% /details %}}
-
-
-### Client for the Global CVE Allocation System
-
-#### Python
-
-{{< cards >}}
-  {{< card link="about" title="gcve" subtitle="A Python client for the Global CVE Allocation System" link="https://github.com/gcve-eu/gcve" image="https://gcve.eu/logos/gcve.png">}}
-{{< /cards >}}
-This `gcve` client can be integrated into software such as Vulnerability-Lookup to provide core GCVE functionalities by adhering to the Best Current Practices and provides a command-line to query the GCVE GNA directory.
-
-{{% details title="Details" %}}
-- {{< icon "github" >}} [https://github.com/gcve-eu/gcve](https://github.com/gcve-eu/gcve)
-{{% /details %}}
-
-
-
-
-
+  <article class="gcve-tool-card">
+    <div class="gcve-tool-card-media">
+      <img src="/logos/gcve.png" alt="GCVE logo" />
+    </div>
+    <div class="gcve-tool-card-body">
+      <p class="gcve-tool-kicker">Python client</p>
+      <h3>gcve</h3>
+      <p>A Python client for the Global CVE Allocation System that can be integrated into software such as Vulnerability-Lookup and used from the command line to query the GCVE GNA directory.</p>
+      <ul class="gcve-tool-list">
+        <li>Provides core GCVE client functionality for applications.</li>
+        <li>Follows GCVE Best Current Practices.</li>
+        <li>Includes command-line access to the GNA directory.</li>
+      </ul>
+      <div class="gcve-tool-actions">
+        <a class="gcve-button gcve-button-primary" href="https://github.com/gcve-eu/gcve">GitHub repository</a>
+      </div>
+    </div>
+  </article>
+</div>


### PR DESCRIPTION
### Motivation
- Make the `/software` page visually consistent with the main homepage by adopting the same hero, card and panel styling so implementers can find projects quickly.
- Surface important tooling (CPE curation and AI-assisted enrichment) that complements existing GCVE reference implementations and validators.

### Description
- Replace the old shortcode-heavy listing with a polished hero section, action buttons and a card-based project grid in `content/software.md` to match the homepage style.
- Add two new project entries: `cpe-editor` (CPE/product curation service and repo link) and "AI-Assisted Vulnerability Information Annotation" (AI enrichment + provenance; GitHub link to `gcve-eu/gcve-eu-ai-extension`).
- Keep and reformat existing projects (vulnerability-lookup, gcve-eu-kev, bcp-validator, `gcve` Python client) in the new card layout for consistent presentation.
- Add responsive CSS for the software hero, stats panel, tool cards, media blocks, hover states and mobile layout in `assets/css/custom.css`.

### Testing
- Ran `git diff --check` with no problems reported.
- Attempted to run a local site build (`hugo --minify`) but Hugo is not available in the environment so the site build could not be executed.
- Attempts to install/run Hugo via `go install`, `apt-get` and a direct GitHub release download were blocked by the environment/network (HTTP 403 responses), so visual QA via a local build was not possible.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a252d8ddd108324b85ab3d170506eda)