### PR TITLE
Fix GCVE logo overlap in software cards

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -592,6 +592,13 @@ body {
   margin-inline: auto;
 }
 
+.content .gcve-tool-card-media img[src$="/logos/gcve.png"] {
+  width: 100%;
+  max-width: min(100%, 7rem);
+  max-height: 5.5rem;
+  margin-inline: 0;
+}
+
 @media (max-width: 1024px), (min-width: 1025px) and (max-width: 1280px) {
   .gcve-hero-grid {
     grid-template-columns: minmax(0, 1fr);


### PR DESCRIPTION
### Motivation
- Prevent the GCVE logo used in software cards from overflowing and covering card text by constraining its rendered size inside the card media container.

### Description
- Add a more specific CSS rule in `assets/css/custom.css` targeting `.content .gcve-tool-card-media img[src$="/logos/gcve.png"]` to cap width and height so the logo stays inside each card while leaving the broader `.content img[src$="/logos/gcve.png"]` rule unchanged.

### Testing
- Ran `git diff --check` which reported no issues.
- Attempted `hugo --minify` but it could not run because `hugo` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a252eb24e688324ae20778832db8c12)