### PR TITLE
Update community coordination label

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -20,7 +20,7 @@ toc: false
         <div class="gcve-stat"><strong>GNA</strong><span>Independent numbering authorities</span></div>
         <div class="gcve-stat"><strong>BCP</strong><span>Open best current practices</span></div>
         <div class="gcve-stat"><strong>JSON</strong><span>Machine-readable directory</span></div>
-        <div class="gcve-stat"><strong>EU</strong><span>Community-led coordination</span></div>
+        <div class="gcve-stat">Community-lead coordination</div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
### Motivation
- Standardize the homepage stat wording by removing the `EU` prefix and the phrase "Community-led coordination" in favor of the single label "Community-lead coordination".

### Description
- Replace the stat entry in `content/_index.md` so the previous `<div class="gcve-stat"><strong>EU</strong><span>Community-led coordination</span></div>` is now `<div class="gcve-stat">Community-lead coordination</div>`.

### Testing
- Ran a search to verify the replacement with `rg -n -U "EU\s*</strong>\s*<span>Community-led coordination|Community-led coordination|Community-lead coordination" content/_index.md` which found the updated line. 
- Ran `git diff --check` which reported no whitespace or merge errors. 
- Attempted `hugo --minify` but it could not be executed in the environment because the `hugo` binary is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25305f28888324a031c0c3f52eeeef)