### PR TITLE
Add /who page describing CIRCL-led initiative and supporters

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -839,3 +839,150 @@ body {
     min-height: 6rem;
   }
 }
+
+.gcve-who-hero .gcve-hero h1,
+.gcve-who-hero h1 {
+  max-width: 14ch;
+}
+
+.gcve-who-panel {
+  gap: 1rem;
+}
+
+.gcve-who-panel > img {
+  max-width: min(100%, 14rem);
+  max-height: 13rem;
+  object-fit: contain;
+}
+
+.gcve-who-panel > p {
+  margin: 0;
+  color: var(--gcve-muted);
+  font-size: 0.98rem;
+  line-height: 1.6;
+  text-align: center;
+}
+
+.gcve-who-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1.15rem;
+  margin: 1.35rem 0 2.75rem;
+}
+
+.gcve-who-card {
+  position: relative;
+  isolation: isolate;
+  display: grid;
+  grid-template-columns: minmax(6.5rem, 0.28fr) minmax(0, 1fr);
+  gap: 1.1rem;
+  overflow: hidden;
+  padding: 1.2rem;
+  border: 1px solid var(--gcve-border);
+  border-radius: 1.35rem;
+  background: var(--gcve-card);
+  box-shadow: 0 16px 38px rgba(16, 35, 63, 0.07);
+  backdrop-filter: blur(14px);
+}
+
+.gcve-who-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  border-radius: inherit;
+  background: linear-gradient(135deg, rgba(38, 100, 255, 0.1), rgba(34, 195, 223, 0.08), transparent 58%);
+}
+
+.gcve-who-card-lead {
+  grid-column: 1 / -1;
+  grid-template-columns: minmax(10rem, 0.3fr) minmax(0, 1fr);
+}
+
+.gcve-who-logo {
+  display: grid;
+  align-self: start;
+  place-items: center;
+  min-height: 7.5rem;
+  padding: 1rem;
+  border: 1px solid rgba(38, 100, 255, 0.11);
+  border-radius: 1.1rem;
+  background: rgba(255, 255, 255, 0.58);
+}
+
+.dark .gcve-who-logo {
+  border-color: rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.gcve-who-logo-light {
+  background: rgba(255, 255, 255, 0.86);
+}
+
+.gcve-who-logo img {
+  max-width: min(100%, 12rem);
+  max-height: 6.5rem;
+  object-fit: contain;
+}
+
+.gcve-who-card-lead .gcve-who-logo img {
+  max-height: 9rem;
+}
+
+.gcve-who-logo-text {
+  color: #174bd6;
+  font-size: clamp(1.45rem, 3vw, 2.3rem);
+  font-weight: 900;
+  letter-spacing: 0.08em;
+}
+
+.dark .gcve-who-logo-text {
+  color: #8be9f7;
+}
+
+.gcve-who-card h3 {
+  margin: 0;
+  color: var(--gcve-ink);
+  font-size: clamp(1.35rem, 2vw, 1.8rem);
+  line-height: 1.08;
+  letter-spacing: -0.05em;
+}
+
+.gcve-who-card p:not(.gcve-tool-kicker) {
+  margin: 0.85rem 0 0;
+  color: var(--gcve-muted);
+  line-height: 1.65;
+}
+
+.gcve-inline-link {
+  display: inline-flex;
+  margin-top: 1rem;
+  color: #174bd6;
+  font-weight: 800;
+  text-decoration: none !important;
+}
+
+.gcve-inline-link:hover {
+  color: #0b7285;
+}
+
+.dark .gcve-inline-link {
+  color: #8be9f7;
+}
+
+@media (max-width: 1180px) {
+  .gcve-who-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+@media (max-width: 720px) {
+  .gcve-who-card,
+  .gcve-who-card-lead {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .gcve-who-logo {
+    min-height: 6rem;
+  }
+}

--- a/content/_index.md
+++ b/content/_index.md
@@ -36,6 +36,7 @@ While remaining compatible with the traditional CVE system, GCVE introduces **GC
 
 {{< cards >}}
   {{< card link="about" title="About GCVE" icon="book-open" subtitle="Understand the goals, design principles, and decentralized allocation model." >}}
+  {{< card link="who" title="Who is behind GCVE?" icon="user-group" subtitle="See the people, organisations, and projects supporting the initiative." >}}
   {{< card link="faq" title="FAQ" icon="chat" subtitle="Quick answers about compatibility, identifiers, GNAs, and participation." >}}
   {{< card link="bcp" title="Best Current Practices" icon="book-open" subtitle="Read the open process documents that guide GCVE operations." >}}
   {{< card link="software" title="Software" icon="desktop-computer" subtitle="Discover implementations, tooling, and integrations around the ecosystem." >}}

--- a/content/who.md
+++ b/content/who.md
@@ -1,0 +1,111 @@
+---
+title: Who is behind GCVE?
+toc: false
+---
+
+<section class="gcve-hero gcve-who-hero">
+  <div class="gcve-hero-grid">
+    <div>
+      <p class="gcve-eyebrow">People, organisations, and projects</p>
+      <h1>Who is behind <span class="gcve-gradient-text">GCVE</span>?</h1>
+      <p class="gcve-hero-lede">GCVE is an initiative led by CIRCL and developed with an open, collaborative community of organisations and people actively contributing to the project.</p>
+      <div class="gcve-hero-actions">
+        <a class="gcve-button gcve-button-primary" href="#contributors-and-supporters">Contributors and supporters</a>
+        <a class="gcve-button gcve-button-secondary" href="https://discourse.ossbase.org/c/gcve/14">Join the discussion</a>
+      </div>
+    </div>
+    <div class="gcve-hero-panel gcve-who-panel" aria-label="GCVE collaboration overview">
+      <img src="/images/circl-logo.png" alt="CIRCL logo" />
+      <p>CIRCL leads the GCVE initiative, with transparent discussions, practical implementations, and community contributions shaping the work.</p>
+      <div class="gcve-stat-grid">
+        <div class="gcve-stat"><strong>CIRCL</strong><span>Initiative lead</span></div>
+        <div class="gcve-stat"><strong>Open</strong><span>Collaborative process</span></div>
+        <div class="gcve-stat"><strong>BCP</strong><span>Community practices</span></div>
+        <div class="gcve-stat"><strong>EU</strong><span>Co-funded extensions</span></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+As mentioned in the [FAQ](/faq/#q12-what-is-the-relationship-between-the-open-source-vulnerability-lookup-project-the-euvd-european-union-vulnerability-database-and-gcveeu), the **GCVE initiative is led by [CIRCL](https://www.circl.lu/)**. The initiative grew from operational experience running vulnerability publication and lookup infrastructure, and it remains closely connected to open-source vulnerability-management work.
+
+GCVE is not only a website or an identifier format. It is a collaborative effort where people who actively contribute to the project help define the technical direction, improve tooling, discuss Best Current Practices, and extend the ecosystem for real-world vulnerability publication use cases.
+
+<h2 id="contributors-and-supporters">Contributors and supporters</h2>
+
+<p class="gcve-section-intro">The GCVE ecosystem is supported by organisations, standards communities, and EU co-funded projects that help sustain the work and expand it into new initiative extensions.</p>
+
+<div class="gcve-who-grid">
+  <article class="gcve-who-card gcve-who-card-lead">
+    <div class="gcve-who-logo">
+      <img src="/images/circl-logo.png" alt="CIRCL logo" />
+    </div>
+    <div>
+      <p class="gcve-tool-kicker">Initiative lead</p>
+      <h3>CIRCL</h3>
+      <p>The Computer Incident Response Center Luxembourg leads GCVE and contributes operational experience from vulnerability management, coordinated disclosure, and open-source tooling.</p>
+      <a class="gcve-inline-link" href="https://www.circl.lu/">Visit CIRCL</a>
+    </div>
+  </article>
+
+  <article class="gcve-who-card">
+    <div class="gcve-who-logo gcve-who-logo-light">
+      <img src="https://ossbase.org/images/logo/logo.svg" alt="ossbase logo" />
+    </div>
+    <div>
+      <p class="gcve-tool-kicker">Community support</p>
+      <h3>ossbase</h3>
+      <p>ossbase supports the open collaboration space around GCVE, including public discussions for BCP topics and community feedback.</p>
+      <a class="gcve-inline-link" href="https://ossbase.org/">Visit ossbase</a>
+    </div>
+  </article>
+
+  <article class="gcve-who-card">
+    <div class="gcve-who-logo gcve-who-logo-light">
+      <img src="/images/projects/misp-logo.png" alt="MISP project logo" />
+    </div>
+    <div>
+      <p class="gcve-tool-kicker">Standards alignment</p>
+      <h3>MISP-standard</h3>
+      <p>MISP-standard helps connect GCVE work with open information-sharing standards and practical interoperability needs in the security community.</p>
+      <a class="gcve-inline-link" href="https://www.misp-standard.org/">Visit MISP-standard</a>
+    </div>
+  </article>
+
+  <article class="gcve-who-card">
+    <div class="gcve-who-logo gcve-who-logo-text" aria-hidden="true">FETTA</div>
+    <div>
+      <p class="gcve-tool-kicker">EU co-funded extension</p>
+      <h3>FETTA</h3>
+      <p>FETTA supports new GCVE initiative extensions and applied work that strengthens open vulnerability publication and coordination capabilities.</p>
+    </div>
+  </article>
+
+  <article class="gcve-who-card">
+    <div class="gcve-who-logo gcve-who-logo-light">
+      <img src="https://cis.ncbj.gov.pl/sites/cis.ncbj.gov.pl/files/2025-09/aipitch.png" alt="AIPITCH logo" />
+    </div>
+    <div>
+      <p class="gcve-tool-kicker">EU co-funded extension</p>
+      <h3>AIPITCH</h3>
+      <p>AIPITCH contributes support for new GCVE initiative extensions, including work at the intersection of vulnerability information, tooling, and assisted analysis.</p>
+    </div>
+  </article>
+
+  <article class="gcve-who-card">
+    <div class="gcve-who-logo gcve-who-logo-light">
+      <img src="https://avatars.githubusercontent.com/u/157494580?s=200&v=4" alt="NGSOTI logo" />
+    </div>
+    <div>
+      <p class="gcve-tool-kicker">EU co-funded extension</p>
+      <h3>NGSOTI</h3>
+      <p>NGSOTI supports the broader open-source vulnerability tooling ecosystem and helps enable extensions connected to GCVE and vulnerability-lookup.</p>
+    </div>
+  </article>
+</div>
+
+## Collaborative by design
+
+GCVE work is collaborative and led by people who actively contribute to the project. Contributions happen through implementation, data modelling, operational feedback, BCP discussions, open-source development, and participation in the GCVE community channels.
+
+The goal is to keep GCVE practical, transparent, and useful for vulnerability publishers, consumers, coordinators, researchers, and software maintainers. The organisations listed above provide leadership, infrastructure, standards alignment, and project support, but the direction of GCVE is shaped by ongoing contributions from the people doing the work.

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -40,24 +40,27 @@ menu:
       name: About
       pageRef: /about
       weight: 1
+    - name: Who
+      pageRef: /who
+      weight: 2
     - name: FAQ 
       pageRef: /faq
-      weight: 2
+      weight: 3
     - name: BCP
       pageRef: /bcp
-      weight: 3
+      weight: 4
     - name: Contact
       pageRef: /contact
-      weight: 4
+      weight: 5
     - name: News
       pageRef: /news
-      weight: 5
+      weight: 6
     - name: Software
       pageRef: /software
-      weight: 6
+      weight: 7
     - name: Open Data
       pageRef: /opendata
-      weight: 7
+      weight: 8
     - name: db.gcve.eu
       url: "https://db.gcve.eu/"
       params:


### PR DESCRIPTION
### Motivation
- Provide a dedicated “Who” page that documents that GCVE is an initiative led by CIRCL and supported by partner organisations, standards communities, and EU co-funded projects. 
- Surface contributors and supporters (ossbase, MISP-standard, FETTA, AIPITCH, NGSOTI) and explain that the work is collaborative and driven by active contributors.

### Description
- Added `content/who.md` with a hero, contributor/supporter cards, and a “Collaborative by design” section describing the CIRCL lead and community-driven nature. 
- Updated the homepage cards in `content/_index.md` to include a link to the new `who` page. 
- Inserted the `Who` menu entry in `hugo.yaml` main navigation so `/who` appears in the primary nav. 
- Added responsive styles for the Who page (hero, cards, logos, layout) in `assets/css/custom.css`.

### Testing
- Ran `git diff --check -- hugo.yaml content/_index.md content/who.md assets/css/custom.css` and there were no diff-check errors. 
- Executed lightweight content assertions with a Python script (front matter presence, expected strings like `CIRCL`, `ossbase`, `MISP-standard`, `FETTA`, `AIPITCH`, `NGSOTI`, and menu/homepage link updates), which passed. 
- Attempted to run `go run github.com/gohugoio/hugo@v0.149.1 version` to verify a local Hugo build, but the Go proxy returned `403 Forbidden` in this environment so a full site build could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2535cd22bc8324bf70ce3a90470e44)