### PR TITLE
Fix FETTA logo overlap on Who page

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -930,10 +930,13 @@ body {
 }
 
 .gcve-who-logo-text {
+  max-width: 100%;
   color: #174bd6;
-  font-size: clamp(1.45rem, 3vw, 2.3rem);
+  font-size: clamp(1.15rem, 1.8vw, 1.5rem);
   font-weight: 900;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.06em;
+  line-height: 1;
+  white-space: nowrap;
 }
 
 .dark .gcve-who-logo-text {


### PR DESCRIPTION
### Motivation
- Prevent the text-based FETTA mark from overflowing its logo tile and overlapping adjacent card content on the Who page by constraining its size and preventing wrapping.

### Description
- Adjusted `.gcve-who-logo-text` in `assets/css/custom.css` to add `max-width: 100%`, reduce the responsive `font-size` to `clamp(1.15rem, 1.8vw, 1.5rem)`, tighten `letter-spacing`, and set `line-height: 1` with `white-space: nowrap` so the logo stays on a single line and no longer spills into neighboring content.

### Testing
- Ran `git diff --check` which reported no issues.
- Attempted to run `hugo --gc --minify` to perform a full site build, but `hugo` is not available in the environment so a build could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25379d6c3c832487c7815797c12a8b)