### PR TITLE
Add cpe.gcve.eu card to Explore section

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -45,5 +45,6 @@ While remaining compatible with the traditional CVE system, GCVE introduces **GC
   {{< card link="/dist/gcve.json" title="Directory JSON" icon="desktop-computer" subtitle="Fetch the GCVE GNA directory as a machine-readable file." >}}
   {{< card link="news" title="News" icon="newspaper" subtitle="Follow announcements, releases, community events, and project updates." >}}
   {{< card link="https://db.gcve.eu" title="db.gcve.eu" icon="database" subtitle="Open the GCVE vulnerability intelligence and lookup service." >}}
+  {{< card link="https://cpe.gcve.eu" title="cpe.gcve.eu" icon="database" subtitle="Open the GCVE CPE catalog and collaborative product curation service." >}}
   {{< card link="contact" title="Contact" icon="mail" subtitle="Reach the GCVE team and join community discussion channels." >}}
 {{< /cards >}}


### PR DESCRIPTION
### Motivation
- Surface the new CPE catalog service in the homepage "Explore GCVE" grid so users can discover and open CPE.GCVE.EU alongside existing services.

### Description
- Add a new explore card in `content/_index.md` immediately after the `db.gcve.eu` card: `{{< card link="https://cpe.gcve.eu" title="cpe.gcve.eu" icon="database" subtitle="Open the GCVE CPE catalog and collaborative product curation service." >}}`.

### Testing
- Attempted to build the site with `hugo --minify --destination /tmp/gcve-hugo-build`, but `hugo` is not installed in the environment so the automated build could not be run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a257667554c8324878102f3beff67bc)