### PR TITLE
Fix Hugo deprecation warnings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/imfing/hextra-starter-template
 go 1.21
 
 require github.com/imfing/hextra v0.8.6 // indirect
+
+replace github.com/imfing/hextra => ./themes/hextra

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/imfing/hextra v0.8.6 h1:fpOqzcUs26Lc/ZzowYSBcnpe00d/aZw4HhiHP7ycSks=
-github.com/imfing/hextra v0.8.6/go.mod h1:cEfel3lU/bSx7lTE/+uuR4GJaphyOyiwNR3PTqFTXpI=

--- a/themes/hextra/assets/js/flexsearch.js
+++ b/themes/hextra/assets/js/flexsearch.js
@@ -12,7 +12,7 @@ document.addEventListener("DOMContentLoaded", function () {
 });
 
 // Render the search data as JSON.
-// {{ $searchDataFile := printf "%s.search-data.json" .Language.Lang }}
+// {{ $searchDataFile := printf "%s.search-data.json" .Language.Name }}
 // {{ $searchData := resources.Get "json/search-data.json" | resources.ExecuteAsTemplate $searchDataFile . }}
 // {{ if hugo.IsProduction }}
 //   {{ $searchData := $searchData | minify | fingerprint }}

--- a/themes/hextra/exampleSite/content/docs/advanced/multi-language.fa.md
+++ b/themes/hextra/exampleSite/content/docs/advanced/multi-language.fa.md
@@ -16,13 +16,13 @@ prev: /docs/advanced
 defaultContentLanguage: en
 languages:
   en:
-    languageName: English
+    label: English
     weight: 1
   fa:
-    languageName: فارسی
+    label: فارسی
     weight: 2
   ja:
-    languageName: 日本語
+    label: 日本語
     weight: 3
 ```
 

--- a/themes/hextra/exampleSite/content/docs/advanced/multi-language.md
+++ b/themes/hextra/exampleSite/content/docs/advanced/multi-language.md
@@ -16,13 +16,13 @@ To make our site multi-language, we need to tell Hugo the supported languages. W
 defaultContentLanguage: en
 languages:
   en:
-    languageName: English
+    label: English
     weight: 1
   fr:
-    languageName: Français
+    label: Français
     weight: 2
   ja:
-    languageName: 日本語
+    label: 日本語
     weight: 3
 ```
 

--- a/themes/hextra/exampleSite/content/docs/advanced/multi-language.zh-cn.md
+++ b/themes/hextra/exampleSite/content/docs/advanced/multi-language.zh-cn.md
@@ -16,13 +16,13 @@ Hextra 支持使用 Hugo 的[多语言模式](https://gohugo.io/content-manageme
 defaultContentLanguage: en
 languages:
   en:
-    languageName: English
+    label: English
     weight: 1
   fr:
-    languageName: Français
+    label: Français
     weight: 2
   ja:
-    languageName: 日本語
+    label: 日本語
     weight: 3
 ```
 

--- a/themes/hextra/exampleSite/hugo.yaml
+++ b/themes/hextra/exampleSite/hugo.yaml
@@ -19,18 +19,18 @@ outputs:
 defaultContentLanguage: en
 languages:
   en:
-    languageName: English
+    label: English
     weight: 1
     title: Hextra
   zh-cn:
-    languageName: 简体中文
-    languageCode: zh-CN
+    label: 简体中文
+    locale: zh-CN
     weight: 2
     title: Hextra
   fa:
-    languageName: فارسی
-    languageCode: fa
-    languageDirection: rtl
+    label: فارسی
+    locale: fa
+    direction: rtl
     weight: 3
     title: هگزترا
 

--- a/themes/hextra/layouts/_default/baseof.html
+++ b/themes/hextra/layouts/_default/baseof.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
-<html lang="{{ .Site.Language.Lang }}">
+<html lang="{{ .Site.Language.Locale }}">
   {{- partial "head.html" . -}}
-  <body dir="{{ .Site.Language.LanguageDirection | default `ltr` }}">
+  <body dir="{{ .Site.Language.Direction | default `ltr` }}">
     {{- partial "navbar.html" . -}}
     {{- block "main" . }}{{ end -}}
     {{- if or (eq .Site.Params.footer.enable nil) (.Site.Params.footer.enable) }}

--- a/themes/hextra/layouts/_default/list.rss.xml
+++ b/themes/hextra/layouts/_default/list.rss.xml
@@ -3,7 +3,7 @@
     <title>{{ .Site.Title }} – {{ .Title }}</title>
     <link>{{ .Permalink }}</link>
     <description>Recent content {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
-    <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
+    <generator>Hugo -- gohugo.io</generator>{{ with .Site.Language.Locale }}
     <language>{{.}}</language>{{end}}{{ with .Site.Author.email }}
     <managingEditor>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Author.email }}
     <webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}

--- a/themes/hextra/layouts/partials/components/giscus.html
+++ b/themes/hextra/layouts/partials/components/giscus.html
@@ -1,4 +1,4 @@
-{{- $lang := site.Language.LanguageCode | default `en` -}}
+{{- $lang := site.Language.Locale | default `en` -}}
 
 {{- with site.Params.comments.giscus -}}
 <script>

--- a/themes/hextra/layouts/partials/language-switch.html
+++ b/themes/hextra/layouts/partials/language-switch.html
@@ -16,7 +16,7 @@
     >
       <div class="hx-flex hx-items-center hx-gap-2 hx-capitalize">
         {{- partial "utils/icon" (dict "name" "globe-alt" "attributes" "height=12") -}}
-        {{- if not $hideLabel }}<span>{{ site.Language.LanguageName }}</span>{{ end -}}
+        {{- if not $hideLabel }}<span>{{ site.Language.Label }}</span>{{ end -}}
       </div>
     </button>
     <ul
@@ -24,14 +24,14 @@
       style="position: fixed; inset: auto auto 0px 0px; margin: 0px; min-width: 100px;"
     >
       {{ range site.Languages }}
-        {{ $link := partial "utils/lang-link" (dict "lang" .Lang "context" $page) }}
+        {{ $link := partial "utils/lang-link" (dict "lang" .Name "context" $page) }}
         <li class="hx-flex hx-flex-col">
           <a
             href="{{ $link }}"
             class="hx-text-gray-800 dark:hx-text-gray-100 hover:hx-bg-primary-50 hover:hx-text-primary-600 hover:dark:hx-bg-primary-500/10 hover:dark:hx-text-primary-600 hx-relative hx-cursor-pointer hx-whitespace-nowrap hx-py-1.5 hx-transition-colors ltr:hx-pl-3 ltr:hx-pr-9 rtl:hx-pr-3 rtl:hx-pl-9"
           >
-            {{- .LanguageName -}}
-            {{- if eq .LanguageName site.Language.LanguageName -}}
+            {{- .Label -}}
+            {{- if eq .Label site.Language.Label -}}
               <span class="hx-absolute hx-inset-y-0 hx-flex hx-items-center ltr:hx-right-3 rtl:hx-left-3">
                 {{- partial "utils/icon" (dict "name" "check" "attributes" "height=1em width=1em") -}}
               </span>

--- a/themes/hextra/layouts/partials/scripts.html
+++ b/themes/hextra/layouts/partials/scripts.html
@@ -18,7 +18,7 @@
 {{- if (site.Params.search.enable | default true) -}}
   {{- $searchType := site.Params.search.type | default "flexsearch" -}}
   {{- if eq $searchType "flexsearch" -}}
-    {{- $jsSearchScript := printf "%s.search.js" .Language.Lang -}}
+    {{- $jsSearchScript := printf "%s.search.js" .Language.Name -}}
     {{- $jsSearch := resources.Get "js/flexsearch.js" | resources.ExecuteAsTemplate $jsSearchScript . -}}
     {{- if hugo.IsProduction -}}
       {{- $jsSearch = $jsSearch | minify | fingerprint -}}

--- a/themes/hextra/layouts/partials/utils/icon.html
+++ b/themes/hextra/layouts/partials/utils/icon.html
@@ -1,5 +1,5 @@
-{{/* Render raw svg icon from .Site.Data */}}
-{{- $icon := index site.Data.icons .name -}}
+{{/* Render raw svg icon from hugo.Data */}}
+{{- $icon := index hugo.Data.icons .name -}}
 
 {{- if not $icon -}}
   {{ errorf "icon %q not found" .name }}

--- a/themes/hextra/layouts/partials/utils/lang-link.html
+++ b/themes/hextra/layouts/partials/utils/lang-link.html
@@ -7,13 +7,13 @@
 {{ $link := false }}
 
 {{ range $page.AllTranslations }}
-  {{ if eq .Language.Lang $lang }}
+  {{ if eq .Language.Name $lang }}
     {{ $link = .RelPermalink }}
   {{ end }}
 {{ end }}
 
 {{ if not $link }}
-  {{ range where $page.Sites ".Language.Lang" $lang }}
+  {{ range where $page.Sites ".Language.Name" $lang }}
     {{ $link = .Home.RelPermalink }}
   {{ end }}
 {{ end }}

--- a/themes/hextra/layouts/shortcodes/icon.html
+++ b/themes/hextra/layouts/shortcodes/icon.html
@@ -1,5 +1,5 @@
 {{- $name := .Get "name" | default (.Get 0) -}}
-{{- $icon := index site.Data.icons $name -}}
+{{- $icon := index hugo.Data.icons $name -}}
 {{- $attributes := .Get "attributes" | default "height=1em"}}
 
 {{- if not $icon -}}


### PR DESCRIPTION
### Motivation
- Remove usage of APIs deprecated in recent Hugo releases so the theme/site is compatible with Hugo v0.158+ and future Hugo versions. 
- Update language-related template usage and example config to use the newer language keys/methods to avoid runtime deprecations. 
- Make the local theme copy the authoritative module source so the patched templates are used during local builds.

### Description
- Replaced deprecated data access `site.Data`/`.Site.Data` with `hugo.Data` in icon shortcodes/partials (`themes/hextra/layouts/partials/utils/icon.html`, `themes/hextra/layouts/shortcodes/icon.html`).
- Replaced deprecated language APIs: `.Site.Language.LanguageDirection` -> `.Site.Language.Direction` and `.Site.LanguageCode` -> `.Site.Language.Locale` (e.g. `themes/hextra/layouts/_default/baseof.html`, `themes/hextra/layouts/_default/list.rss.xml`, `themes/hextra/layouts/partials/components/giscus.html`).
- Normalized language naming APIs to current names: `languageName` -> `label`, `languageDirection` -> `direction`, `.Lang`/`.Language.Lang` -> `.Name`/`.Language.Name` and `.LanguageName` -> `.Label` in language helpers and templates (language switcher, lang-link, scripts, example docs). 
- Updated example site configuration and docs to use `locale`, `label`, and `direction` keys (`themes/hextra/exampleSite/hugo.yaml`, example content files). 
- Added a local module replacement so `github.com/imfing/hextra` resolves to `./themes/hextra` via `go.mod` (and removed `go.sum` to keep local replacement tidy).

### Testing
- Ran `go mod verify` which succeeded. 
- Ran `go list -m all` which confirmed the module resolution to the local theme copy. 
- Verified there are no remaining occurrences of the deprecated patterns with a repository search using `rg` (no matches remaining). 
- Attempt to run `hugo --source /workspace/gcve.eu --gc --minify` could not be completed because `hugo` is not installed in the execution environment, so a full Hugo build was not performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25772c4edc83249b184b019ce082b5)