### PR TITLE
Make homepage BCP mention clickable

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -517,9 +517,29 @@ body {
   background: rgba(255, 255, 255, 0.58);
 }
 
+.gcve-stat[href] {
+  text-decoration: none !important;
+  transition: transform 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease, background-color 0.18s ease;
+}
+
+.gcve-stat[href]:hover,
+.gcve-stat[href]:focus-visible {
+  border-color: rgba(38, 100, 255, 0.28);
+  background: rgba(255, 255, 255, 0.78);
+  box-shadow: 0 12px 28px rgba(16, 35, 63, 0.11);
+  transform: translateY(-2px);
+}
+
 .dark .gcve-stat {
   border-color: rgba(255, 255, 255, 0.08);
   background: rgba(255, 255, 255, 0.05);
+}
+
+.dark .gcve-stat[href]:hover,
+.dark .gcve-stat[href]:focus-visible {
+  border-color: rgba(34, 195, 223, 0.28);
+  background: rgba(255, 255, 255, 0.08);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.24);
 }
 
 .gcve-stat strong {

--- a/content/_index.md
+++ b/content/_index.md
@@ -18,7 +18,7 @@ toc: false
       <img src="/logos/gcve.png" alt="GCVE logo" />
       <div class="gcve-stat-grid">
         <div class="gcve-stat"><strong>GNA</strong><span>Independent numbering authorities</span></div>
-        <div class="gcve-stat"><strong>BCP</strong><span>Open best current practices</span></div>
+        <a class="gcve-stat" href="/bcp/" aria-label="Open GCVE Best Current Practices"><strong>BCP</strong><span>Open best current practices</span></a>
         <div class="gcve-stat"><strong>JSON</strong><span>Machine-readable directory</span></div>
         <div class="gcve-stat">Community-lead coordination</div>
       </div>


### PR DESCRIPTION
### Motivation
- Make the BCP item in the homepage hero interactive so users can navigate directly to the BCP landing page.

### Description
- Replace the homepage static `div` for BCP with an anchor linking to `/bcp/` and add an `aria-label` for accessibility in `content/_index.md`.
- Add hover and `focus-visible` styles for `.gcve-stat[href]` and dark-mode variants in `assets/css/custom.css` so the clickable stat preserves the existing hero-card appearance.

### Testing
- Ran `git diff --check` with no issues.
- Executed a Python assertion verifying the anchor exists in `content/_index.md` which passed.
- Attempted `hugo --minify` but Hugo is not installed in the environment, so a full site build could not be run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a257d0edc508324af7f36f239107b1e)