### PR TITLE
Add GCVE Community Board to who page

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1367,3 +1367,149 @@ body {
     padding: 1rem;
   }
 }
+
+.gcve-board-section {
+  position: relative;
+  overflow: hidden;
+  margin: 2.5rem 0 3rem;
+  padding: clamp(1.25rem, 3vw, 2rem);
+  border: 1px solid var(--gcve-border);
+  border-radius: 1.6rem;
+  background:
+    radial-gradient(circle at top left, rgba(38, 100, 255, 0.12), transparent 34rem),
+    radial-gradient(circle at bottom right, rgba(34, 195, 223, 0.14), transparent 28rem),
+    var(--gcve-card);
+  box-shadow: 0 20px 52px rgba(16, 35, 63, 0.08);
+}
+
+.gcve-board-header {
+  max-width: 68rem;
+}
+
+.gcve-board-header h2 {
+  margin: 0.35rem 0 1rem;
+  color: var(--gcve-ink);
+  font-size: clamp(2rem, 5vw, 3.7rem);
+  line-height: 0.98;
+  letter-spacing: -0.065em;
+}
+
+.gcve-board-header p:not(.gcve-eyebrow) {
+  margin: 0.85rem 0 0;
+  color: var(--gcve-muted);
+  font-size: 1.02rem;
+  line-height: 1.72;
+}
+
+.gcve-board-meta {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.9rem;
+  margin: 1.6rem 0 2rem;
+}
+
+.gcve-board-meta-item {
+  padding: 1rem;
+  border: 1px solid rgba(38, 100, 255, 0.12);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.55);
+}
+
+.dark .gcve-board-meta-item {
+  border-color: rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.gcve-board-meta-item strong,
+.gcve-board-meta-item span {
+  display: block;
+}
+
+.gcve-board-meta-item strong {
+  color: var(--gcve-ink);
+  font-size: 1rem;
+}
+
+.gcve-board-meta-item span {
+  margin-top: 0.35rem;
+  color: var(--gcve-muted);
+  font-size: 0.92rem;
+  line-height: 1.45;
+}
+
+.gcve-board-members-heading {
+  margin: 0 0 1rem;
+  color: var(--gcve-ink);
+  font-size: clamp(1.4rem, 2vw, 1.9rem);
+  letter-spacing: -0.035em;
+}
+
+.gcve-board-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.gcve-member-card {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  min-height: 8rem;
+  padding: 1rem;
+  border: 1px solid var(--gcve-border);
+  border-radius: 1.15rem;
+  background: rgba(255, 255, 255, 0.72);
+  box-shadow: 0 12px 30px rgba(16, 35, 63, 0.06);
+}
+
+.dark .gcve-member-card {
+  background: rgba(255, 255, 255, 0.045);
+}
+
+.gcve-member-avatar {
+  display: grid;
+  flex: 0 0 4.35rem;
+  width: 4.35rem;
+  height: 4.35rem;
+  place-items: center;
+  border-radius: 1rem;
+  background: linear-gradient(135deg, #174bd6, #22c3df);
+  color: #fff;
+  font-weight: 900;
+  letter-spacing: 0.055em;
+  box-shadow: 0 14px 28px rgba(23, 75, 214, 0.2);
+}
+
+.gcve-member-card h4 {
+  margin: 0;
+  color: var(--gcve-ink);
+  font-size: 1.1rem;
+  line-height: 1.15;
+  letter-spacing: -0.025em;
+}
+
+.gcve-member-card p {
+  margin: 0.35rem 0 0;
+  color: var(--gcve-muted);
+  font-size: 0.95rem;
+  line-height: 1.35;
+}
+
+@media (max-width: 1180px) {
+  .gcve-board-grid,
+  .gcve-board-meta {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 720px) {
+  .gcve-board-grid,
+  .gcve-board-meta {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .gcve-member-card {
+    min-height: 0;
+  }
+}

--- a/content/who.md
+++ b/content/who.md
@@ -10,7 +10,8 @@ toc: false
       <h1>Who is behind <span class="gcve-gradient-text">GCVE</span>?</h1>
       <p class="gcve-hero-lede">GCVE is an initiative led by CIRCL and developed with an open, collaborative community of organisations and people actively contributing to the project.</p>
       <div class="gcve-hero-actions">
-        <a class="gcve-button gcve-button-primary" href="#contributors-and-supporters">Contributors and supporters</a>
+        <a class="gcve-button gcve-button-primary" href="#gcve-community-board">Community Board</a>
+        <a class="gcve-button gcve-button-secondary" href="#contributors-and-supporters">Contributors and supporters</a>
         <a class="gcve-button gcve-button-secondary" href="https://discourse.ossbase.org/c/gcve/14">Join the discussion</a>
       </div>
     </div>
@@ -30,6 +31,67 @@ toc: false
 As mentioned in the [FAQ](/faq/#q12-what-is-the-relationship-between-the-open-source-vulnerability-lookup-project-the-euvd-european-union-vulnerability-database-and-gcveeu), the **GCVE initiative is led by [CIRCL](https://www.circl.lu/)**. The initiative grew from operational experience running vulnerability publication and lookup infrastructure, and it remains closely connected to open-source vulnerability-management work.
 
 GCVE is not only a website or an identifier format. It is a collaborative effort where people who actively contribute to the project help define the technical direction, improve tooling, discuss Best Current Practices, and extend the ecosystem for real-world vulnerability publication use cases.
+
+<section class="gcve-board-section" id="gcve-community-board">
+  <div class="gcve-board-header">
+    <p class="gcve-eyebrow">Open governance and practical expertise</p>
+    <h2>GCVE Community Board</h2>
+    <p>The GCVE Community Board is composed of people who contribute regularly to the GCVE initiative and provide constructive feedback, useful input, and practical expertise to help advance the field of vulnerability identification and intelligence. Its role is to support the evolution of GCVE, from Best Current Practice documents to concrete software implementations, with the objective of serving the global vulnerability intelligence community.</p>
+    <p>The board operates in an open and collaborative manner. A permanent chat room is available for ongoing discussions, coordination, and exchange of ideas. In addition, a monthly online meeting is organized to discuss important topics, review progress, and address proposals or challenges related to GCVE. The discussions and outcomes of these monthly meetings are public, ensuring transparency and encouraging broader community participation.</p>
+  </div>
+
+  <div class="gcve-board-meta" aria-label="GCVE Community Board working model">
+    <div class="gcve-board-meta-item"><strong>Permanent chat</strong><span>Ongoing coordination and exchange of ideas.</span></div>
+    <div class="gcve-board-meta-item"><strong>Monthly meeting</strong><span>Online discussion of progress, proposals, and challenges.</span></div>
+    <div class="gcve-board-meta-item"><strong>Public outcomes</strong><span>Transparent meeting discussions and outcomes.</span></div>
+  </div>
+
+  <h3 class="gcve-board-members-heading">Members (confirmed)</h3>
+  <div class="gcve-board-grid">
+    <article class="gcve-member-card">
+      <div class="gcve-member-avatar" aria-hidden="true">CB</div>
+      <div>
+        <h4>Cédric Bonhomme</h4>
+        <p>CIRCL</p>
+      </div>
+    </article>
+    <article class="gcve-member-card">
+      <div class="gcve-member-avatar" aria-hidden="true">AD</div>
+      <div>
+        <h4>Alexandre Dulaunoy</h4>
+        <p>CIRCL</p>
+      </div>
+    </article>
+    <article class="gcve-member-card">
+      <div class="gcve-member-avatar" aria-hidden="true">DD</div>
+      <div>
+        <h4>David Durvaux</h4>
+        <p>European Commission</p>
+      </div>
+    </article>
+    <article class="gcve-member-card">
+      <div class="gcve-member-avatar" aria-hidden="true">JG</div>
+      <div>
+        <h4>Jerry Gamblin</h4>
+        <p>Rogolabs</p>
+      </div>
+    </article>
+    <article class="gcve-member-card">
+      <div class="gcve-member-avatar" aria-hidden="true">JJ</div>
+      <div>
+        <h4>Jay Jacobs</h4>
+        <p>Empirical Security</p>
+      </div>
+    </article>
+    <article class="gcve-member-card">
+      <div class="gcve-member-avatar" aria-hidden="true">EL</div>
+      <div>
+        <h4>Eireann Leverett</h4>
+        <p>Concinnity Risks</p>
+      </div>
+    </article>
+  </div>
+</section>
 
 <h2 id="contributors-and-supporters">Contributors and supporters</h2>
 


### PR DESCRIPTION
### Motivation
- Introduce a dedicated GCVE Community Board section to describe the board's role, working model, and confirmed members.
- Surface the board from the hero area with a shortcut link so visitors can quickly find governance and community contacts.

### Description
- Added a new `GCVE Community Board` section to `content/who.md` containing the requested descriptive text, working-model highlights (permanent chat, monthly meeting, public outcomes), and confirmed member cards for the six listed members.
- Added a hero shortcut pointing to the new board and preserved the existing contributors and discussion links in `content/who.md`.
- Added responsive styling and component rules to `assets/css/custom.css` for the board panel, metadata items, member cards, initials avatars, dark mode behavior, and mobile breakpoints.

### Testing
- Ran `git diff --check` which reported no whitespace or diff-check issues.
- Attempted to run `hugo` to build the site but the `hugo` binary is not available in the environment, so a local build could not be completed.
- Attempted to install `hugo` with `go install` but external module access was blocked by the environment (HTTP 403), so installation failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2597cb96f483249c0b925b7efa8e59)