### PR TITLE
Add Citation page and link from homepage and About

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -39,6 +39,7 @@ While remaining compatible with the traditional CVE system, GCVE introduces **GC
   {{< card link="who" title="Who is behind GCVE?" icon="user-group" subtitle="See the people, organisations, and projects supporting the initiative." >}}
   {{< card link="faq" title="FAQ" icon="chat" subtitle="Quick answers about compatibility, identifiers, GNAs, and participation." >}}
   {{< card link="bcp" title="Best Current Practices" icon="book-open" subtitle="Read the open process documents that guide GCVE operations." >}}
+  {{< card link="citation" title="Citation" icon="academic-cap" subtitle="Find the recommended citation and BibTeX entry for referencing the GCVE initiative." >}}
   {{< card link="software" title="Software" icon="desktop-computer" subtitle="Discover implementations, tooling, and integrations around the ecosystem." >}}
   {{< card link="opendata" title="Open Data" icon="database" subtitle="Find public vulnerability dumps, GCVE/GNA source data, and enriched advisory data sets." >}}
   {{< card link="gna" title="GNA Directory" icon="book-open" subtitle="Browse participating GCVE Numbering Authorities and related metadata." >}}

--- a/content/about.md
+++ b/content/about.md
@@ -9,6 +9,10 @@ While remaining compatible with the traditional CVE system, GCVE introduces **GC
 
 **Global CVE (GCVE)** initiative is operated by the [CIRCL Computer Incident Response Center Luxembourg](http://www.circl.lu/), which also maintains the core open-source project for vulnerability management, [vulnerability-lookup](https://www.vulnerability-lookup.org/). For more details, see [the background story](https://gcve.eu/faq/#q12-what-is-the-relationship-between-the-open-source-vulnerability-lookup-project-the-euvd-european-union-vulnerability-database-and-gcveeu).
 
+## Citing GCVE
+
+If you reference the GCVE initiative in academic, technical, or operational publications, please use the recommended citation and BibTeX entry on the [Citation](/citation/) page.
+
 ## Key Concepts
 
 ![Overview of the GCVE.eu allocation system](/images/gcve-overview.png)

--- a/content/citation.md
+++ b/content/citation.md
@@ -1,0 +1,80 @@
+---
+title: Citation
+toc: true
+---
+
+# How to cite the GCVE initiative
+
+When referencing the **Global CVE (GCVE)** initiative, please cite the arXiv paper that describes the decentralized model for vulnerability identification, publication, and operational enrichment.
+
+## Recommended citation
+
+Dulaunoy, A. (2026). *GCVE: A Decentralized Model for Vulnerability Identification, Publication, and Operational Enrichment*. arXiv:2606.00856 [cs.CR]. https://doi.org/10.48550/arXiv.2606.00856
+
+- Paper: [https://arxiv.org/abs/2606.00856](https://arxiv.org/abs/2606.00856)
+- DOI: [https://doi.org/10.48550/arXiv.2606.00856](https://doi.org/10.48550/arXiv.2606.00856)
+
+## Related GCVE research and models
+
+The following papers describe models and approaches developed in the GCVE ecosystem and related vulnerability intelligence workflows.
+
+### AI-assisted severity classification
+
+Bonhomme, C., & Dulaunoy, A. (2025). *VLAI: A RoBERTa-Based Model for Automated Vulnerability Severity Classification*. arXiv:2507.03607 [cs.CR]. https://doi.org/10.48550/arXiv.2507.03607
+
+This work was developed to support AI-assisted severity classification in the scope of GCVE and related vulnerability management workflows.
+
+- Paper: [https://arxiv.org/abs/2507.03607](https://arxiv.org/abs/2507.03607)
+- DOI: [https://doi.org/10.48550/arXiv.2507.03607](https://doi.org/10.48550/arXiv.2507.03607)
+
+### Vulnerability sighting activity prediction
+
+Bonhomme, C., & Dulaunoy, A. (2026). *Modeling Sparse and Bursty Vulnerability Sightings: Forecasting Under Data Constraints*. arXiv:2604.16038 [cs.CR]. https://doi.org/10.48550/arXiv.2604.16038
+
+This work was developed to predict sighting activities on vulnerability information and to explore forecasting approaches for sparse, bursty vulnerability-related events.
+
+- Paper: [https://arxiv.org/abs/2604.16038](https://arxiv.org/abs/2604.16038)
+- DOI: [https://doi.org/10.48550/arXiv.2604.16038](https://doi.org/10.48550/arXiv.2604.16038)
+
+## BibTeX
+
+```bibtex
+@misc{dulaunoy2026gcve,
+  title = {GCVE: A Decentralized Model for Vulnerability Identification, Publication, and Operational Enrichment},
+  author = {Dulaunoy, Alexandre},
+  year = {2026},
+  eprint = {2606.00856},
+  archivePrefix = {arXiv},
+  primaryClass = {cs.CR},
+  doi = {10.48550/arXiv.2606.00856},
+  url = {https://arxiv.org/abs/2606.00856}
+}
+
+@misc{bonhomme2025vlai,
+  title = {VLAI: A RoBERTa-Based Model for Automated Vulnerability Severity Classification},
+  author = {Bonhomme, Cédric and Dulaunoy, Alexandre},
+  year = {2025},
+  eprint = {2507.03607},
+  archivePrefix = {arXiv},
+  primaryClass = {cs.CR},
+  doi = {10.48550/arXiv.2507.03607},
+  url = {https://arxiv.org/abs/2507.03607}
+}
+
+@misc{bonhomme2026sightings,
+  title = {Modeling Sparse and Bursty Vulnerability Sightings: Forecasting Under Data Constraints},
+  author = {Bonhomme, Cedric and Dulaunoy, Alexandre},
+  year = {2026},
+  eprint = {2604.16038},
+  archivePrefix = {arXiv},
+  primaryClass = {cs.CR},
+  doi = {10.48550/arXiv.2604.16038},
+  url = {https://arxiv.org/abs/2604.16038}
+}
+```
+
+## In text
+
+A concise in-text reference can be written as:
+
+> The Global CVE (GCVE) initiative is a decentralized model for vulnerability identification, publication, and enrichment (Dulaunoy, 2026).


### PR DESCRIPTION
### Motivation
- Provide a clear, discoverable recommended citation and BibTeX entry for the GCVE initiative to support academic and technical references.
- Surface citation guidance on the main site so visitors can quickly find how to reference GCVE in publications.

### Description
- Added a new `content/citation.md` page containing the recommended citation, related GCVE research references, and BibTeX entries.
- Added a "Citation" card to the homepage in `content/_index.md` to link to the new citation page.
- Added a short "Citing GCVE" section to `content/about.md` that points readers to the `Citation` page.

### Testing
- Performed a static site build with `hugo` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25d6bb5808832483fcaeb331957e3a)