### PR TITLE
Add BCP layout and styles for Best Current Practice pages

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1513,3 +1513,258 @@ body {
     min-height: 0;
   }
 }
+
+.gcve-bcp-shell {
+  position: relative;
+  overflow: hidden;
+  margin: 1.5rem 0 3rem;
+  border: 1px solid var(--gcve-border);
+  border-radius: 1.8rem;
+  background:
+    radial-gradient(circle at top left, rgba(38, 100, 255, 0.13), transparent 34rem),
+    radial-gradient(circle at top right, rgba(34, 195, 223, 0.13), transparent 28rem),
+    var(--gcve-card);
+  box-shadow: var(--gcve-shadow);
+  backdrop-filter: blur(18px);
+}
+
+.gcve-bcp-shell::before {
+  content: "";
+  position: absolute;
+  inset: 0 0 auto;
+  height: 0.35rem;
+  background: linear-gradient(90deg, var(--gcve-blue), var(--gcve-cyan), var(--gcve-lime));
+}
+
+.gcve-bcp-hero {
+  padding: clamp(1.5rem, 3vw, 2.6rem) clamp(1.25rem, 3vw, 2.75rem) 1.3rem;
+  border-bottom: 1px solid rgba(38, 100, 255, 0.11);
+}
+
+.dark .gcve-bcp-hero {
+  border-bottom-color: rgba(255, 255, 255, 0.08);
+}
+
+.gcve-bcp-hero h1 {
+  max-width: 62rem;
+  margin: 0.35rem 0 0;
+  color: var(--gcve-ink);
+  font-size: clamp(2.1rem, 4.6vw, 4.5rem);
+  font-weight: 900;
+  line-height: 0.98;
+  letter-spacing: -0.075em;
+}
+
+.gcve-bcp-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1.35rem;
+}
+
+.gcve-bcp-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.55rem;
+  padding: 0.62rem 1rem;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  background: linear-gradient(135deg, var(--gcve-blue), var(--gcve-cyan));
+  color: #fff !important;
+  font-size: 0.92rem;
+  font-weight: 800;
+  text-decoration: none !important;
+  box-shadow: 0 14px 34px rgba(38, 100, 255, 0.24);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.gcve-bcp-action:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 42px rgba(38, 100, 255, 0.3);
+}
+
+.gcve-bcp-action-secondary {
+  border-color: var(--gcve-border);
+  background: rgba(255, 255, 255, 0.68);
+  color: var(--gcve-ink) !important;
+  box-shadow: none;
+}
+
+.dark .gcve-bcp-action-secondary {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.gcve-bcp-document {
+  padding: clamp(1.25rem, 3vw, 2.75rem);
+  color: var(--gcve-ink);
+}
+
+.gcve-bcp-document > h1:first-child {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.gcve-bcp-document > p:first-of-type:has(img) {
+  display: flex;
+  justify-content: flex-start;
+  margin: -0.5rem 0 1.5rem;
+}
+
+.gcve-bcp-document > p:first-of-type img {
+  width: auto;
+  max-height: 4.2rem;
+  padding: 0.65rem;
+  border: 1px solid rgba(38, 100, 255, 0.12);
+  border-radius: 1.1rem;
+  background: rgba(255, 255, 255, 0.72);
+  box-shadow: 0 14px 32px rgba(16, 35, 63, 0.08);
+}
+
+.dark .gcve-bcp-document > p:first-of-type img {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.gcve-bcp-document > ul:first-of-type {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.85rem;
+  margin: 0 0 1.5rem;
+  padding: 0;
+  list-style: none;
+}
+
+.gcve-bcp-document > ul:first-of-type li {
+  margin: 0;
+  padding: 0.95rem 1rem;
+  border: 1px solid rgba(38, 100, 255, 0.12);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.58);
+  color: var(--gcve-muted);
+  line-height: 1.45;
+}
+
+.dark .gcve-bcp-document > ul:first-of-type li {
+  border-color: rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.gcve-bcp-document > ul:first-of-type li strong {
+  color: var(--gcve-ink);
+}
+
+.gcve-bcp-document > p:nth-of-type(2) {
+  margin: 1.25rem 0 0.25rem;
+  padding: 1rem 1.1rem;
+  border-left: 0.28rem solid var(--gcve-cyan);
+  border-radius: 0 1rem 1rem 0;
+  background: rgba(34, 195, 223, 0.08);
+  color: var(--gcve-muted);
+}
+
+.gcve-bcp-document h2 {
+  margin-top: 2.2rem;
+  padding-top: 1.1rem;
+  border-top: 1px solid rgba(38, 100, 255, 0.12);
+  color: var(--gcve-ink);
+  font-size: clamp(1.45rem, 2.5vw, 2rem);
+  letter-spacing: -0.045em;
+}
+
+.dark .gcve-bcp-document h2 {
+  border-top-color: rgba(255, 255, 255, 0.08);
+}
+
+.gcve-bcp-document h3 {
+  color: var(--gcve-ink);
+  letter-spacing: -0.025em;
+}
+
+.gcve-bcp-document p,
+.gcve-bcp-document li {
+  color: var(--gcve-muted);
+  line-height: 1.72;
+}
+
+.gcve-bcp-document a {
+  color: #174bd6;
+  font-weight: 700;
+  text-decoration-thickness: 0.08em;
+  text-underline-offset: 0.18em;
+}
+
+.dark .gcve-bcp-document a {
+  color: #8be9f7;
+}
+
+.gcve-bcp-document blockquote {
+  border-color: var(--gcve-cyan);
+  border-radius: 0 1rem 1rem 0;
+  background: rgba(34, 195, 223, 0.08);
+}
+
+.gcve-bcp-document table {
+  overflow: hidden;
+  border: 1px solid rgba(38, 100, 255, 0.12);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.52);
+}
+
+.dark .gcve-bcp-document table {
+  border-color: rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.gcve-bcp-document thead {
+  background: rgba(38, 100, 255, 0.08);
+}
+
+.dark .gcve-bcp-document thead {
+  background: rgba(34, 195, 223, 0.1);
+}
+
+.gcve-bcp-document th {
+  color: var(--gcve-ink);
+  font-weight: 850;
+}
+
+.gcve-bcp-document :not(pre) > code {
+  border: 1px solid rgba(38, 100, 255, 0.12);
+  border-radius: 0.45rem;
+  background: rgba(38, 100, 255, 0.07);
+  color: #174bd6;
+}
+
+.dark .gcve-bcp-document :not(pre) > code {
+  border-color: rgba(255, 255, 255, 0.08);
+  background: rgba(34, 195, 223, 0.1);
+  color: #8be9f7;
+}
+
+.gcve-bcp-document pre {
+  border: 1px solid rgba(38, 100, 255, 0.12);
+  border-radius: 1rem;
+}
+
+@media (max-width: 920px) {
+  .gcve-bcp-document > ul:first-of-type {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .gcve-bcp-shell {
+    border-radius: 1.25rem;
+  }
+
+  .gcve-bcp-document > ul:first-of-type {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/layouts/bcp/single.html
+++ b/layouts/bcp/single.html
@@ -1,0 +1,33 @@
+{{ define "main" }}
+<div class='hx-mx-auto hx-flex {{ partial "utils/page-width" . }}'>
+  {{ partial "sidebar.html" (dict "context" . "disableSidebar" true
+  "displayPlaceholder" true) }} {{ partial "toc.html" . }}
+  <article
+    class="hx-w-full hx-break-words hx-flex hx-min-h-[calc(100vh-var(--navbar-height))] hx-min-w-0 hx-justify-center hx-pb-8 hx-pr-[calc(env(safe-area-inset-right)-1.5rem)]"
+  >
+    <main class="hx-w-full hx-min-w-0 hx-max-w-6xl hx-px-6 hx-pt-4 md:hx-px-12">
+      <div class="gcve-bcp-shell">
+        <header class="gcve-bcp-hero">
+          <p class="gcve-eyebrow">GCVE Best Current Practice</p>
+          {{ if .Title }}
+          <h1>{{ .Title }}</h1>
+          {{ end }}
+          <div class="gcve-bcp-actions" aria-label="BCP document actions">
+            <a href="/bcp/" class="gcve-bcp-action gcve-bcp-action-secondary"
+              >BCP index</a
+            >
+            {{ $pdfPath := printf "/files/bcp/%s.pdf" .File.BaseFileName }} {{
+            if fileExists (printf "static%s" $pdfPath) }}
+            <a href="{{ $pdfPath }}" class="gcve-bcp-action">Download PDF</a>
+            {{ end }}
+          </div>
+        </header>
+        <div class="content gcve-bcp-document">{{ .Content }}</div>
+      </div>
+      <div class="hx-mt-16"></div>
+      {{ partial "components/last-updated.html" . }} {{ partial
+      "components/comments.html" . }}
+    </main>
+  </article>
+</div>
+{{ end }}


### PR DESCRIPTION
### Motivation

- Provide a dedicated layout and visual style for "Best Current Practice" (BCP) documents to improve readability, presentation, and provide quick actions like a PDF download and index link.

### Description

- Add a new layout `layouts/bcp/single.html` that renders BCP pages with a hero, action buttons (including conditional PDF link detection via `fileExists`), content wrapper, and includes `last-updated` and `comments` components.
- Extend `assets/css/custom.css` with a comprehensive set of BCP-specific styles (`.gcve-bcp-shell`, `.gcve-bcp-hero`, `.gcve-bcp-actions`, `.gcve-bcp-document`, etc.) including responsive rules and dark-mode adjustments.
- Implement visual details such as gradient accents, rounded card styling, accessible hidden heading for content, and enhanced code/table/blockquote styling for BCP pages.

### Testing

- Built the site with `hugo` and verified the BCP pages render using the new layout without build errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a265f30c508832485d76f325ab65f5d)