### PR TITLE
Widen BCP detail pages

### DIFF
--- a/layouts/bcp/single.html
+++ b/layouts/bcp/single.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
 <div class='hx-mx-auto hx-flex {{ partial "utils/page-width" . }}'>
   {{ partial "sidebar.html" (dict "context" . "disableSidebar" true
-  "displayPlaceholder" true) }} {{ partial "toc.html" . }}
+  "displayPlaceholder" false) }} {{ partial "toc.html" . }}
   <article
     class="hx-w-full hx-break-words hx-flex hx-min-h-[calc(100vh-var(--navbar-height))] hx-min-w-0 hx-justify-center hx-pb-8 hx-pr-[calc(env(safe-area-inset-right)-1.5rem)]"
   >


### PR DESCRIPTION
### Motivation
- BCP detail pages reserved a disabled sidebar placeholder on desktop which left the left-hand area empty, so the content should use that space while keeping the right-side table of contents visible.

### Description
- Updated `layouts/bcp/single.html` to set the sidebar `displayPlaceholder` flag to `false`, removing the desktop placeholder and allowing the BCP document area to expand into the left-side space.

### Testing
- Ran `themes/hextra/node_modules/.bin/prettier --check layouts/bcp/single.html` and `git diff --check`, both succeeded; a full `hugo` build could not be run because `hugo` is not installed and attempts to install it were blocked by repository/proxy 403 responses.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2668b31bdc83248994bd5f1ecd0d9f)