### PR TITLE
Improve GNA directory and profile layouts

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1768,3 +1768,502 @@ body {
     grid-template-columns: minmax(0, 1fr);
   }
 }
+
+.gcve-gna-hero,
+.gcve-gna-profile {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  margin: 1.5rem 0 3rem;
+  border: 1px solid var(--gcve-border);
+  border-radius: 1.8rem;
+  background:
+    radial-gradient(circle at top left, rgba(38, 100, 255, 0.13), transparent 34rem),
+    radial-gradient(circle at top right, rgba(34, 195, 223, 0.13), transparent 28rem),
+    var(--gcve-card);
+  box-shadow: var(--gcve-shadow);
+  backdrop-filter: blur(18px);
+}
+
+.gcve-gna-hero::before,
+.gcve-gna-profile::before {
+  content: "";
+  position: absolute;
+  inset: 0 0 auto;
+  z-index: 1;
+  height: 0.35rem;
+  background: linear-gradient(90deg, var(--gcve-blue), var(--gcve-cyan), var(--gcve-lime));
+}
+
+.gcve-gna-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(18rem, 0.85fr);
+  gap: clamp(1.5rem, 4vw, 4rem);
+  align-items: center;
+  padding: clamp(1.5rem, 4vw, 3rem);
+}
+
+.gcve-gna-hero h1,
+.gcve-gna-profile-hero h1,
+.gcve-gna-section-head h2 {
+  margin: 0.35rem 0 0;
+  color: var(--gcve-ink);
+  font-weight: 900;
+  line-height: 0.98;
+  letter-spacing: -0.075em;
+}
+
+.gcve-gna-hero h1 {
+  max-width: 11ch;
+  font-size: clamp(3rem, 6vw, 5.4rem);
+}
+
+.gcve-gna-lede,
+.gcve-gna-profile-name,
+.gcve-gna-muted {
+  color: var(--gcve-muted);
+  line-height: 1.7;
+}
+
+.gcve-gna-lede {
+  max-width: 50rem;
+  margin: 1.25rem 0 0;
+  font-size: clamp(1.05rem, 1.8vw, 1.25rem);
+}
+
+.gcve-gna-actions,
+.gcve-gna-profile-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+  margin-top: 1.75rem;
+}
+
+.gcve-gna-panel {
+  display: grid;
+  gap: 1rem;
+  padding: 1.25rem;
+  border: 1px solid var(--gcve-border);
+  border-radius: 1.5rem;
+  background: rgba(255, 255, 255, 0.58);
+  box-shadow: 0 18px 54px rgba(16, 35, 63, 0.11);
+}
+
+.dark .gcve-gna-panel {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.gcve-gna-panel img {
+  width: min(100%, 18rem);
+  max-height: 8rem;
+  margin: 0 auto;
+  object-fit: contain;
+}
+
+.gcve-gna-directory {
+  margin: 0 0 3rem;
+}
+
+.gcve-gna-section-head {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 1.25rem;
+  margin-bottom: 1.35rem;
+}
+
+.gcve-gna-section-head h2 {
+  font-size: clamp(2rem, 4.2vw, 3.4rem);
+}
+
+.gcve-gna-filter {
+  display: grid;
+  gap: 0.4rem;
+  width: min(100%, 28rem);
+  color: var(--gcve-muted);
+  font-size: 0.82rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.gcve-gna-filter input {
+  min-height: 2.8rem;
+  border: 1px solid var(--gcve-border);
+  border-radius: 999px;
+  padding: 0.65rem 1rem;
+  background: var(--gcve-card);
+  color: var(--gcve-ink);
+  font-size: 0.95rem;
+  font-weight: 650;
+  letter-spacing: normal;
+  text-transform: none;
+  box-shadow: 0 12px 28px rgba(16, 35, 63, 0.06);
+}
+
+.gcve-gna-filter input:focus {
+  outline: 3px solid rgba(34, 195, 223, 0.24);
+  border-color: rgba(34, 195, 223, 0.5);
+}
+
+.gcve-gna-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.gcve-gna-card,
+.gcve-gna-detail-card {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  padding: 1.2rem;
+  border: 1px solid var(--gcve-border);
+  border-radius: 1.35rem;
+  background: var(--gcve-card);
+  box-shadow: 0 16px 38px rgba(16, 35, 63, 0.07);
+  backdrop-filter: blur(14px);
+}
+
+.gcve-gna-card {
+  display: flex;
+  min-height: 15rem;
+  flex-direction: column;
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.gcve-gna-card::before,
+.gcve-gna-detail-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  border-radius: inherit;
+  background: linear-gradient(135deg, rgba(38, 100, 255, 0.11), rgba(34, 195, 223, 0.08), transparent 58%);
+  opacity: 0;
+  transition: opacity 0.2s ease;
+}
+
+.gcve-gna-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(34, 195, 223, 0.42);
+  box-shadow: 0 24px 54px rgba(16, 35, 63, 0.13);
+}
+
+.gcve-gna-card:hover::before,
+.gcve-gna-detail-card::before {
+  opacity: 1;
+}
+
+.gcve-gna-card[hidden] {
+  display: none;
+}
+
+.gcve-gna-card-top {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.9rem;
+}
+
+.gcve-gna-id,
+.gcve-gna-vendor {
+  display: inline-flex;
+  align-items: center;
+  min-height: 2rem;
+  padding: 0.4rem 0.68rem;
+  border-radius: 999px;
+  font-size: 0.74rem;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.gcve-gna-id {
+  border: 1px solid rgba(38, 100, 255, 0.15);
+  background: rgba(38, 100, 255, 0.08);
+  color: #174bd6;
+  letter-spacing: 0.08em;
+}
+
+.dark .gcve-gna-id {
+  border-color: rgba(139, 233, 247, 0.2);
+  background: rgba(34, 195, 223, 0.12);
+  color: #8be9f7;
+}
+
+.gcve-gna-vendor {
+  max-width: 100%;
+  border: 1px solid rgba(34, 195, 223, 0.24);
+  background: rgba(34, 195, 223, 0.1);
+  color: #0b7285;
+  text-transform: uppercase;
+}
+
+.dark .gcve-gna-vendor {
+  color: #8be9f7;
+}
+
+.gcve-gna-card h3 {
+  margin: 0;
+  color: var(--gcve-ink);
+  font-size: clamp(1.35rem, 2vw, 1.75rem);
+  line-height: 1.08;
+  letter-spacing: -0.05em;
+}
+
+.gcve-gna-card h3 a {
+  color: inherit;
+  text-decoration: none !important;
+}
+
+.gcve-gna-card h3 a:hover {
+  color: #174bd6;
+}
+
+.dark .gcve-gna-card h3 a:hover {
+  color: #8be9f7;
+}
+
+.gcve-gna-card p {
+  margin: 0.85rem 0 0;
+  color: var(--gcve-muted);
+  line-height: 1.6;
+}
+
+.gcve-gna-card-links,
+.gcve-gna-resource-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+}
+
+.gcve-gna-card-links {
+  margin-top: auto;
+  padding-top: 1.15rem;
+}
+
+.gcve-gna-card-links a,
+.gcve-gna-resource-list a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2.35rem;
+  padding: 0.55rem 0.82rem;
+  border: 1px solid var(--gcve-border);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.66);
+  color: var(--gcve-ink) !important;
+  font-size: 0.9rem;
+  font-weight: 800;
+  text-decoration: none !important;
+}
+
+.dark .gcve-gna-card-links a,
+.dark .gcve-gna-resource-list a {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.gcve-gna-card-links a:first-child,
+.gcve-gna-resource-list a:first-child {
+  color: #fff !important;
+  border-color: transparent;
+  background: linear-gradient(135deg, var(--gcve-blue), var(--gcve-cyan));
+}
+
+.gcve-gna-empty {
+  margin: 1.25rem 0 0;
+  padding: 1rem 1.15rem;
+  border: 1px solid var(--gcve-border);
+  border-radius: 1rem;
+  background: var(--gcve-card);
+  color: var(--gcve-muted);
+  font-weight: 700;
+}
+
+.gcve-gna-profile-hero {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.25rem;
+  padding: clamp(1.5rem, 3vw, 2.6rem) clamp(1.25rem, 3vw, 2.75rem);
+  border-bottom: 1px solid rgba(38, 100, 255, 0.11);
+}
+
+.dark .gcve-gna-profile-hero {
+  border-bottom-color: rgba(255, 255, 255, 0.08);
+}
+
+.gcve-gna-profile-hero h1 {
+  font-size: clamp(2.4rem, 5vw, 4.8rem);
+}
+
+.gcve-gna-profile-name {
+  max-width: 62rem;
+  margin: 1rem 0 0;
+  font-size: clamp(1.05rem, 1.8vw, 1.25rem);
+}
+
+.gcve-gna-profile-badge {
+  display: grid;
+  flex: 0 0 auto;
+  place-items: center;
+  width: clamp(7rem, 13vw, 10rem);
+  min-height: clamp(7rem, 13vw, 10rem);
+  border: 1px solid rgba(34, 195, 223, 0.28);
+  border-radius: 1.4rem;
+  background: linear-gradient(135deg, rgba(38, 100, 255, 0.14), rgba(34, 195, 223, 0.14));
+  color: var(--gcve-ink);
+  box-shadow: 0 18px 42px rgba(16, 35, 63, 0.1);
+}
+
+.gcve-gna-profile-badge span,
+.gcve-gna-profile-badge strong {
+  display: block;
+  line-height: 1;
+}
+
+.gcve-gna-profile-badge span {
+  color: var(--gcve-muted);
+  font-size: 0.8rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+}
+
+.gcve-gna-profile-badge strong {
+  margin-top: 0.5rem;
+  font-size: clamp(2.4rem, 5vw, 4rem);
+  letter-spacing: -0.08em;
+}
+
+.gcve-gna-profile-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(18rem, 0.9fr);
+  gap: 1rem;
+  padding: clamp(1.25rem, 3vw, 2.75rem);
+}
+
+.gcve-gna-detail-card-main {
+  grid-row: span 2;
+}
+
+.gcve-gna-detail-card h2 {
+  margin: 0 0 1rem;
+  color: var(--gcve-ink);
+  font-size: clamp(1.4rem, 2.4vw, 2rem);
+  letter-spacing: -0.045em;
+}
+
+.gcve-gna-definition-list {
+  display: grid;
+  gap: 0.75rem;
+  margin: 0;
+}
+
+.gcve-gna-definition-list div {
+  display: grid;
+  grid-template-columns: minmax(8rem, 0.28fr) minmax(0, 1fr);
+  gap: 0.75rem;
+  padding: 0.85rem;
+  border: 1px solid rgba(38, 100, 255, 0.11);
+  border-radius: 0.95rem;
+  background: rgba(255, 255, 255, 0.52);
+}
+
+.dark .gcve-gna-definition-list div {
+  border-color: rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.gcve-gna-definition-list dt {
+  color: var(--gcve-muted);
+  font-size: 0.82rem;
+  font-weight: 850;
+  text-transform: uppercase;
+}
+
+.gcve-gna-definition-list dd {
+  margin: 0;
+  color: var(--gcve-ink);
+  font-weight: 750;
+  overflow-wrap: anywhere;
+}
+
+.gcve-gna-definition-list code {
+  border: 1px solid rgba(38, 100, 255, 0.12);
+  border-radius: 0.45rem;
+  padding: 0.15rem 0.35rem;
+  background: rgba(38, 100, 255, 0.07);
+  color: #174bd6;
+}
+
+.dark .gcve-gna-definition-list code {
+  color: #8be9f7;
+  background: rgba(34, 195, 223, 0.1);
+}
+
+.gcve-gna-note-card p {
+  margin: 0;
+  color: var(--gcve-muted);
+  line-height: 1.7;
+}
+
+.gcve-gna-resource-list {
+  align-items: stretch;
+}
+
+.gcve-gna-resource-list a {
+  display: grid;
+  justify-items: start;
+  max-width: 100%;
+  border-radius: 1rem;
+  text-align: left;
+}
+
+.gcve-gna-resource-list a span {
+  max-width: 100%;
+  margin-top: 0.18rem;
+  color: inherit;
+  font-size: 0.78rem;
+  font-weight: 600;
+  opacity: 0.72;
+  overflow-wrap: anywhere;
+}
+
+.gcve-gna-profile-actions {
+  margin: 0;
+  padding: 0 clamp(1.25rem, 3vw, 2.75rem) clamp(1.25rem, 3vw, 2.75rem);
+}
+
+@media (max-width: 1180px) {
+  .gcve-gna-hero,
+  .gcve-gna-profile-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .gcve-gna-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 760px) {
+  .gcve-gna-hero,
+  .gcve-gna-profile {
+    border-radius: 1.25rem;
+  }
+
+  .gcve-gna-section-head,
+  .gcve-gna-profile-hero {
+    display: grid;
+    align-items: start;
+  }
+
+  .gcve-gna-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .gcve-gna-definition-list div {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/content/gna/0/index.html
+++ b/content/gna/0/index.html
@@ -1,0 +1,6 @@
+---
+title: "GNA 0 \u2014 CVE"
+description: "CVE Program is registered as GCVE Numbering Authority 0."
+layout: single
+gna_id: 0
+---

--- a/content/gna/1/index.html
+++ b/content/gna/1/index.html
@@ -1,0 +1,6 @@
+---
+title: "GNA 1 \u2014 CIRCL"
+description: "Computer Incident Response Center Luxembourg is registered as GCVE Numbering Authority 1."
+layout: single
+gna_id: 1
+---

--- a/content/gna/100/index.html
+++ b/content/gna/100/index.html
@@ -1,0 +1,6 @@
+---
+title: "GNA 100 \u2014 VulDB"
+description: "vuldb.com is registered as GCVE Numbering Authority 100."
+layout: single
+gna_id: 100
+---

--- a/content/gna/101/index.html
+++ b/content/gna/101/index.html
@@ -1,0 +1,6 @@
+---
+title: "GNA 101 \u2014 ERIC"
+description: "Ericsson AB is registered as GCVE Numbering Authority 101."
+layout: single
+gna_id: 101
+---

--- a/content/gna/102/index.html
+++ b/content/gna/102/index.html
@@ -1,0 +1,6 @@
+---
+title: "GNA 102 \u2014 EACG"
+description: "Enterprise Architecture Consulting Group is registered as GCVE Numbering Authority 102."
+layout: single
+gna_id: 102
+---

--- a/content/gna/103/index.html
+++ b/content/gna/103/index.html
@@ -1,0 +1,6 @@
+---
+title: "GNA 103 \u2014 SCHUTZWERK"
+description: "SCHUTZWERK GmbH is registered as GCVE Numbering Authority 103."
+layout: single
+gna_id: 103
+---

--- a/content/gna/104/index.html
+++ b/content/gna/104/index.html
@@ -1,0 +1,6 @@
+---
+title: "GNA 104 \u2014 AboutCode.org"
+description: "AboutCode Europe ASBL is registered as GCVE Numbering Authority 104."
+layout: single
+gna_id: 104
+---

--- a/content/gna/105/index.html
+++ b/content/gna/105/index.html
@@ -1,0 +1,6 @@
+---
+title: "GNA 105 \u2014 OPC"
+description: "OPC Foundation is registered as GCVE Numbering Authority 105."
+layout: single
+gna_id: 105
+---

--- a/content/gna/106/index.html
+++ b/content/gna/106/index.html
@@ -1,0 +1,6 @@
+---
+title: "GNA 106 \u2014 SK-CERT"
+description: "National Cyber Security Centre SK-CERT is registered as GCVE Numbering Authority 106."
+layout: single
+gna_id: 106
+---

--- a/content/gna/107/index.html
+++ b/content/gna/107/index.html
@@ -1,0 +1,6 @@
+---
+title: "GNA 107 \u2014 THA-PSIRT"
+description: "Thales PSIRT is registered as GCVE Numbering Authority 107."
+layout: single
+gna_id: 107
+---

--- a/content/gna/108/index.html
+++ b/content/gna/108/index.html
@@ -1,0 +1,6 @@
+---
+title: "GNA 108 \u2014 Securin"
+description: "Securin Inc is registered as GCVE Numbering Authority 108."
+layout: single
+gna_id: 108
+---

--- a/content/gna/109/index.html
+++ b/content/gna/109/index.html
@@ -1,0 +1,6 @@
+---
+title: "GNA 109 \u2014 concinnity-risks"
+description: "Concinnity Risks LLC is registered as GCVE Numbering Authority 109."
+layout: single
+gna_id: 109
+---

--- a/content/gna/110/index.html
+++ b/content/gna/110/index.html
@@ -1,0 +1,6 @@
+---
+title: "GNA 110 \u2014 VVD"
+description: "Vulnetix Vulnerability Database is registered as GCVE Numbering Authority 110."
+layout: single
+gna_id: 110
+---

--- a/content/gna/111/index.html
+++ b/content/gna/111/index.html
@@ -1,0 +1,6 @@
+---
+title: "GNA 111 \u2014 MOGWAILABS"
+description: "MOGWAI LABS GmbH is registered as GCVE Numbering Authority 111."
+layout: single
+gna_id: 111
+---

--- a/content/gna/112/index.html
+++ b/content/gna/112/index.html
@@ -1,0 +1,6 @@
+---
+title: "GNA 112 \u2014 CERT-QC"
+description: "Minist\u00e8re de la Cybers\u00e9curit\u00e9 et du Num\u00e9rique \u2013 CERT-QC is registered as GCVE Numbering Authority 112."
+layout: single
+gna_id: 112
+---

--- a/content/gna/113/index.html
+++ b/content/gna/113/index.html
@@ -1,0 +1,6 @@
+---
+title: "GNA 113 \u2014 Krones"
+description: "Krones AG is registered as GCVE Numbering Authority 113."
+layout: single
+gna_id: 113
+---

--- a/content/gna/114/index.html
+++ b/content/gna/114/index.html
@@ -1,0 +1,6 @@
+---
+title: "GNA 114 \u2014 siemens"
+description: "Siemens is registered as GCVE Numbering Authority 114."
+layout: single
+gna_id: 114
+---

--- a/content/gna/115/index.html
+++ b/content/gna/115/index.html
@@ -1,0 +1,6 @@
+---
+title: "GNA 115 \u2014 Adrian Dacka"
+description: "Adrian \"syrex1013\" Dacka is registered as GCVE Numbering Authority 115."
+layout: single
+gna_id: 115
+---

--- a/content/gna/116/index.html
+++ b/content/gna/116/index.html
@@ -1,0 +1,6 @@
+---
+title: "GNA 116 \u2014 FLAT"
+description: "Fluid Attacks is registered as GCVE Numbering Authority 116."
+layout: single
+gna_id: 116
+---

--- a/content/gna/117/index.html
+++ b/content/gna/117/index.html
@@ -1,0 +1,6 @@
+---
+title: "GNA 117 \u2014 Moksha"
+description: "Moksha is registered as GCVE Numbering Authority 117."
+layout: single
+gna_id: 117
+---

--- a/content/gna/118/index.html
+++ b/content/gna/118/index.html
@@ -1,0 +1,6 @@
+---
+title: "GNA 118 \u2014 Nozomi Networks"
+description: "Nozomi Networks, Inc. is registered as GCVE Numbering Authority 118."
+layout: single
+gna_id: 118
+---

--- a/content/gna/119/index.html
+++ b/content/gna/119/index.html
@@ -1,0 +1,6 @@
+---
+title: "GNA 119 \u2014 olearysec"
+description: "olearysec.com Security Research is registered as GCVE Numbering Authority 119."
+layout: single
+gna_id: 119
+---

--- a/content/gna/120/index.html
+++ b/content/gna/120/index.html
@@ -1,0 +1,6 @@
+---
+title: "GNA 120 \u2014 eef"
+description: "Erlang Ecosystem Foundation is registered as GCVE Numbering Authority 120."
+layout: single
+gna_id: 120
+---

--- a/content/gna/1291/index.html
+++ b/content/gna/1291/index.html
@@ -1,0 +1,6 @@
+---
+title: "GNA 1291 \u2014 NCSC-CH"
+description: "National Cyber Security Centre (NCSC) - Switzerland is registered as GCVE Numbering Authority 1291."
+layout: single
+gna_id: 1291
+---

--- a/content/gna/1337/index.html
+++ b/content/gna/1337/index.html
@@ -1,0 +1,6 @@
+---
+title: "GNA 1337 \u2014 AHA!"
+description: "Austin Hackers Anonymous is registered as GCVE Numbering Authority 1337."
+layout: single
+gna_id: 1337
+---

--- a/content/gna/2/index.html
+++ b/content/gna/2/index.html
@@ -1,0 +1,6 @@
+---
+title: "GNA 2 \u2014 EUVD"
+description: "European Union Vulnerability Database is registered as GCVE Numbering Authority 2."
+layout: single
+gna_id: 2
+---

--- a/content/gna/2342/index.html
+++ b/content/gna/2342/index.html
@@ -1,0 +1,6 @@
+---
+title: "GNA 2342 \u2014 Pentagrid"
+description: "Pentagrid AG is registered as GCVE Numbering Authority 2342."
+layout: single
+gna_id: 2342
+---

--- a/content/gna/3/index.html
+++ b/content/gna/3/index.html
@@ -1,0 +1,6 @@
+---
+title: "GNA 3 \u2014 Red Hat"
+description: "Red Hat Inc. is registered as GCVE Numbering Authority 3."
+layout: single
+gna_id: 3
+---

--- a/content/gna/31337/index.html
+++ b/content/gna/31337/index.html
@@ -1,0 +1,6 @@
+---
+title: "GNA 31337 \u2014 Talos"
+description: "Cisco Talos is registered as GCVE Numbering Authority 31337."
+layout: single
+gna_id: 31337
+---

--- a/content/gna/404/index.html
+++ b/content/gna/404/index.html
@@ -1,0 +1,6 @@
+---
+title: "GNA 404 \u2014 VulnCheck"
+description: "VulnCheck Inc. is registered as GCVE Numbering Authority 404."
+layout: single
+gna_id: 404
+---

--- a/content/gna/65535/index.html
+++ b/content/gna/65535/index.html
@@ -1,0 +1,6 @@
+---
+title: "GNA 65535 \u2014 TEST-GNA-GCVE"
+description: "GNA id used for testing only is registered as GCVE Numbering Authority 65535."
+layout: single
+gna_id: 65535
+---

--- a/content/gna/680/index.html
+++ b/content/gna/680/index.html
@@ -1,0 +1,6 @@
+---
+title: "GNA 680 \u2014 DFN-CERT"
+description: "DFN-CERT Services GmbH is registered as GCVE Numbering Authority 680."
+layout: single
+gna_id: 680
+---

--- a/content/gna/79/index.html
+++ b/content/gna/79/index.html
@@ -1,0 +1,6 @@
+---
+title: "GNA 79 \u2014 SWISSCOM"
+description: "Swisscom (Schweiz) AG is registered as GCVE Numbering Authority 79."
+layout: single
+gna_id: 79
+---

--- a/content/gna/_index.html
+++ b/content/gna/_index.html
@@ -1,0 +1,5 @@
+---
+title: GNA Directory
+description: Directory of GCVE Numbering Authorities (GNAs), generated from the public GCVE registry data.
+layout: list
+---

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -46,21 +46,24 @@ menu:
     - name: FAQ 
       pageRef: /faq
       weight: 3
+    - name: GNA
+      pageRef: /gna
+      weight: 4
     - name: BCP
       pageRef: /bcp
-      weight: 4
+      weight: 5
     - name: Contact
       pageRef: /contact
-      weight: 5
+      weight: 6
     - name: News
       pageRef: /news
-      weight: 6
+      weight: 7
     - name: Software
       pageRef: /software
-      weight: 7
+      weight: 8
     - name: Open Data
       pageRef: /opendata
-      weight: 8
+      weight: 9
     - name: db.gcve.eu
       url: "https://db.gcve.eu/"
       params:

--- a/layouts/gna/list.html
+++ b/layouts/gna/list.html
@@ -1,0 +1,84 @@
+{{ define "main" }}
+  {{- $raw := readFile "static/dist/gcve.json" -}}
+  {{- $gnas := $raw | transform.Unmarshal -}}
+  {{- $resourceCount := 0 -}}
+  {{- range $gnas }}{{ with .gcve_url }}{{ $resourceCount = add $resourceCount 1 }}{{ end }}{{ end -}}
+  <div class="hx-mx-auto hx-flex {{ partial `utils/page-width` . }}">
+    {{ partial "sidebar.html" (dict "context" . "disableSidebar" true "displayPlaceholder" true) }}
+    <article class="hx-w-full hx-break-words hx-flex hx-min-h-[calc(100vh-var(--navbar-height))] hx-min-w-0 hx-justify-center hx-pb-8 hx-pr-[calc(env(safe-area-inset-right)-1.5rem)]">
+      <main class="hx-w-full hx-min-w-0 hx-max-w-6xl hx-px-6 hx-pt-4 md:hx-px-12">
+        <section class="gcve-gna-hero" aria-labelledby="gna-directory-title">
+          <div class="gcve-gna-hero-copy">
+            <p class="gcve-eyebrow">GCVE registry</p>
+            <h1 id="gna-directory-title">{{ .Title }}</h1>
+            <p class="gcve-gna-lede">GCVE Numbering Authorities are autonomous participants that allocate and publish GCVE identifiers. This directory is generated from the public registry data used by the GCVE initiative.</p>
+            <div class="gcve-gna-actions">
+              <a class="gcve-button gcve-button-primary" href="/publishing-vulnerability-information/">Request a GNA ID</a>
+              <a class="gcve-button gcve-button-secondary" href="/dist/gcve.json">Download JSON</a>
+            </div>
+          </div>
+          <div class="gcve-gna-panel" aria-label="GNA registry summary">
+            <img src="/gcve-logos/GNA/SVG/GNA_color.svg" alt="GCVE Numbering Authority logo" />
+            <div class="gcve-stat-grid">
+              <div class="gcve-stat"><strong>{{ len $gnas }}</strong><span>Registered GNA identifiers</span></div>
+              <div class="gcve-stat"><strong>{{ $resourceCount }}</strong><span>Entries with public URLs</span></div>
+              <div class="gcve-stat"><strong>JSON</strong><span>Published open registry data</span></div>
+              <div class="gcve-stat"><strong>GCVE</strong><span>Decentralized allocation model</span></div>
+            </div>
+          </div>
+        </section>
+
+        <section class="gcve-gna-directory" aria-labelledby="gna-list-title">
+          <div class="gcve-gna-section-head">
+            <div>
+              <p class="gcve-eyebrow">Directory</p>
+              <h2 id="gna-list-title">Registered authorities</h2>
+            </div>
+            <label class="gcve-gna-filter">
+              <span>Filter GNAs</span>
+              <input type="search" id="gna-filter" placeholder="Search by ID, name, vendor, or URL" autocomplete="off" />
+            </label>
+          </div>
+          <div class="gcve-gna-grid" id="gna-grid">
+            {{- range sort $gnas "id" "asc" }}
+              {{- $searchText := printf "%v %s %s %s %s %s %s %s %s %s" .id (or .short_name "") (or .full_name "") (or .cpe_vendor_name "") (or .usage "") (or .gcve_url "") (or .gcve_api "") (or .gcve_dump "") (or .gcve_allocation "") (or .gcve_pull_api "") -}}
+              <article class="gcve-gna-card" data-gna-card data-search="{{ $searchText | plainify | lower }}">
+                <div class="gcve-gna-card-top">
+                  <span class="gcve-gna-id">GNA {{ .id }}</span>
+                  {{ with .cpe_vendor_name }}<span class="gcve-gna-vendor">{{ . }}</span>{{ end }}
+                </div>
+                <h3><a href="/gna/{{ .id }}/">{{ .short_name }}</a></h3>
+                <p>{{ or .full_name .usage "GCVE Numbering Authority registry entry." }}</p>
+                <div class="gcve-gna-card-links">
+                  <a href="/gna/{{ .id }}/">View profile</a>
+                  {{ with .gcve_url }}<a href="{{ . }}" target="_blank" rel="noreferrer">Website</a>{{ end }}
+                </div>
+              </article>
+            {{- end }}
+          </div>
+          <p class="gcve-gna-empty" id="gna-empty" hidden>No GNA entries match your filter.</p>
+        </section>
+      </main>
+    </article>
+    <div class="max-xl:hx-hidden hx-h-0 hx-w-64 hx-shrink-0"></div>
+  </div>
+  <script>
+    (() => {
+      const filter = document.getElementById('gna-filter');
+      const cards = Array.from(document.querySelectorAll('[data-gna-card]'));
+      const empty = document.getElementById('gna-empty');
+      if (!filter || cards.length === 0) return;
+      const applyFilter = () => {
+        const query = filter.value.trim().toLowerCase();
+        let visible = 0;
+        for (const card of cards) {
+          const match = !query || card.dataset.search.includes(query);
+          card.hidden = !match;
+          if (match) visible += 1;
+        }
+        if (empty) empty.hidden = visible !== 0;
+      };
+      filter.addEventListener('input', applyFilter);
+    })();
+  </script>
+{{ end }}

--- a/layouts/gna/single.html
+++ b/layouts/gna/single.html
@@ -1,0 +1,89 @@
+{{ define "main" }}
+  {{- $gna := .Params.gna -}}
+  {{- if not $gna -}}
+    {{- $raw := readFile "static/dist/gcve.json" -}}
+    {{- $gnas := $raw | transform.Unmarshal -}}
+    {{- $targetID := printf "%v" .Params.gna_id -}}
+    {{- range $gnas -}}
+      {{- if eq (printf "%v" .id) $targetID -}}{{- $gna = . -}}{{- end -}}
+    {{- end -}}
+  {{- end -}}
+  {{- $resources := slice
+    (dict "label" "Website" "value" (or $gna.gcve_url ""))
+    (dict "label" "API" "value" (or $gna.gcve_api ""))
+    (dict "label" "Dumps" "value" (or $gna.gcve_dump ""))
+    (dict "label" "Allocation" "value" (or $gna.gcve_allocation ""))
+    (dict "label" "Pull API" "value" (or $gna.gcve_pull_api ""))
+  -}}
+  <div class="hx-mx-auto hx-flex {{ partial `utils/page-width` . }}">
+    {{ partial "sidebar.html" (dict "context" . "disableSidebar" true "displayPlaceholder" true) }}
+    {{ partial "toc.html" . }}
+    <article class="hx-w-full hx-break-words hx-flex hx-min-h-[calc(100vh-var(--navbar-height))] hx-min-w-0 hx-justify-center hx-pb-8 hx-pr-[calc(env(safe-area-inset-right)-1.5rem)]">
+      <main class="hx-w-full hx-min-w-0 hx-max-w-6xl hx-px-6 hx-pt-4 md:hx-px-12">
+        {{ partial "breadcrumb.html" . }}
+        <div class="gcve-gna-profile">
+          <header class="gcve-gna-profile-hero">
+            <div>
+              <p class="gcve-eyebrow">GCVE Numbering Authority</p>
+              <h1>{{ $gna.short_name }}</h1>
+              <p class="gcve-gna-profile-name">{{ or $gna.full_name $gna.usage }}</p>
+            </div>
+            <div class="gcve-gna-profile-badge" aria-label="GNA identifier">
+              <span>GNA</span>
+              <strong>{{ $gna.id }}</strong>
+            </div>
+          </header>
+
+          <section class="gcve-gna-profile-grid" aria-label="GNA metadata">
+            <div class="gcve-gna-detail-card gcve-gna-detail-card-main">
+              <h2>Registry details</h2>
+              <dl class="gcve-gna-definition-list">
+                <div><dt>Identifier</dt><dd>GNA {{ $gna.id }}</dd></div>
+                <div><dt>Short name</dt><dd>{{ $gna.short_name }}</dd></div>
+                {{ with $gna.full_name }}<div><dt>Full name</dt><dd>{{ . }}</dd></div>{{ end }}
+                {{ with $gna.cpe_vendor_name }}<div><dt>CPE vendor</dt><dd><code>{{ . }}</code></dd></div>{{ end }}
+                {{ with $gna.inserted_at }}<div><dt>Inserted</dt><dd>{{ time.AsTime . | time.Format ":date_long" }}</dd></div>{{ end }}
+                {{ with $gna.updated_at }}<div><dt>Updated</dt><dd>{{ time.AsTime . | time.Format ":date_long" }}</dd></div>{{ end }}
+              </dl>
+            </div>
+
+            {{ with $gna.usage }}
+              <div class="gcve-gna-detail-card gcve-gna-note-card">
+                <h2>Usage note</h2>
+                <p>{{ . }}</p>
+              </div>
+            {{ end }}
+
+            <div class="gcve-gna-detail-card">
+              <h2>Publication resources</h2>
+              <div class="gcve-gna-resource-list">
+                {{- range $resources }}
+                  {{- $resource := . -}}
+                  {{- with $resource.value }}
+                    <a href="{{ . }}" target="_blank" rel="noreferrer">
+                      <strong>{{ $resource.label }}</strong>
+                      <span>{{ . }}</span>
+                    </a>
+                  {{- end }}
+                {{- end }}
+              </div>
+              {{- $hasResources := false -}}
+              {{- range $resources }}{{ with .value }}{{ $hasResources = true }}{{ end }}{{ end -}}
+              {{- if not $hasResources }}
+                <p class="gcve-gna-muted">No publication resource URLs are listed for this GNA.</p>
+              {{- end }}
+            </div>
+          </section>
+
+          <nav class="gcve-gna-profile-actions" aria-label="GNA profile actions">
+            <a class="gcve-button gcve-button-secondary" href="/gna/">Back to GNA directory</a>
+            <a class="gcve-button gcve-button-primary" href="/dist/gcve.json">Download registry JSON</a>
+          </nav>
+        </div>
+        <div class="hx-mt-16"></div>
+        {{ partial "components/last-updated.html" . }}
+        {{ partial "components/comments.html" . }}
+      </main>
+    </article>
+  </div>
+{{ end }}


### PR DESCRIPTION
### Motivation
- Make the GNA directory and each `/gna/<ID>/` profile presentationally coherent with the site’s existing GCVE visual language without changing original Markdown sources. 
- Surface registry data from `static/dist/gcve.json` so visitors can browse GNAs, inspect metadata and follow publication links. 
- Provide a searchable, responsive directory and a clear profile page for each GNA to improve discoverability and usability. 

### Description
- Addded a GNA section to the main navigation by updating `hugo.yaml`. 
- Added dedicated templates `layouts/gna/list.html` and `layouts/gna/single.html` that read `static/dist/gcve.json`, generate the directory and per-ID profiles, and provide filtering, CTA buttons and breadcrumb integration. 
- Generated non-Markdown content stubs under `content/gna/<ID>/index.html` for every registry entry so each `/gna/<ID>/` has a renderable page while leaving all original Markdown files untouched. 
- Extended `assets/css/custom.css` with `gcve-gna-*` styles to match existing hero/card/badge UI patterns and added client-side filtering JS to the list layout; improved resource link rendering and safe handling for missing fields in the single layout. 

### Testing
- Verified registry/page mapping with `python3` assertion that the set of IDs in `static/dist/gcve.json` matches generated `content/gna/<ID>/index.html` pages (result: `33 registry entries, 33 generated entry pages`).
- Validated JSON with `jq empty static/dist/gcve.json` (result: `gcve.json valid`).
- Ran pre-commit checks with `git diff --cached --check` and `git diff HEAD --check` which reported no issues.
- Attempted a local site build with `hugo --minify --destination /tmp/gcve-public` but the container lacks Hugo and installation was blocked by environment proxy, so a full rendered build could not be performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29569bb6288324a41c75eb08d359b3)