### PR TITLE
Update BCP-05-X-01 GNA provenance levels (v1.2)

### DIFF
--- a/content/bcp/extension/gcve-bcp-05-x-01.md
+++ b/content/bcp/extension/gcve-bcp-05-x-01.md
@@ -7,9 +7,9 @@ description: "An extension to GCVE BCP-05 to support the annotation of vulnerabi
 
 ![](https://gcve.eu/logos/gcve.png)
 
-- **Version**: 1.1
+- **Version**: 1.2
 - **Status**: Published
-- **Date**: 2026-05-18
+- **Date**: 2026-06-14
 - **Authors**: GCVE Working Group
 - **BCP Extended ID**: BCP-05
 - **BCP ID**: BCP-05-X-01 
@@ -78,7 +78,7 @@ The extension SHALL be embedded under:
     "ai_annotations": [
       {
         "scope": "record | field",
-        "gna_source":  "integer",
+        "gna_source": "integer (optional annotation-level provenance)",
         "field_name": "string (optional if scope=record)",
         "tags": ["string"],
         "description": "string",
@@ -87,6 +87,7 @@ The extension SHALL be embedded under:
         "models": [
           {
             "name": "string",
+            "gna_source": "integer (optional model-level provenance)",
             "version": "string (optional)",
             "provider": "string (optional)",
             "source": "ollama | huggingface | local | other",
@@ -207,15 +208,23 @@ Examples:
 
 ### gna_source
 
-Identifies the GCVE Numbering Authority (GNA) responsible for producing, publishing, or asserting the AI annotation.
+Identifies the GCVE Numbering Authority (GNA) responsible for producing, publishing, or asserting an AI annotation or the use of a specific model within an AI annotation.
 
-The `gna_source` value MUST be the numeric identifier of the GNA that performed or contributed the AI annotation.
+The `gna_source` value MUST be the numeric identifier of the GNA that performed, contributed, published, or asserted the corresponding AI-assisted operation.
 
 The `gna_source` field MUST be represented as an integer value.
 
-The `gna_source` field SHOULD be present for every AI annotation to support provenance, traceability, and accountability across decentralized GCVE producers.
+The `gna_source` field MAY appear at the AI annotation level. When present at this level, it identifies the GNA responsible for the annotation as a whole and acts as the default provenance source for model entries that do not define their own `gna_source`.
 
-Consumers SHOULD treat `gna_source` as a provenance signal indicating the source of the AI annotation, not as a guarantee of correctness.
+The `gna_source` field MAY also appear inside each entry of the `models` array. When present at the model level, it identifies the GNA responsible for that model's contribution, assertion, execution, or enrichment and overrides the annotation-level `gna_source` for that model entry.
+
+The same AI annotation MAY include an annotation-level `gna_source` and one or more model-level `gna_source` values. This represents cases where one GNA publishes or curates the annotation while another GNA provides, runs, or asserts a specific model-derived enrichment.
+
+At least one `gna_source` SHOULD be present either on the AI annotation or on each model entry whenever AI-assisted processing occurred and the GNA provenance is known. Producers SHOULD prefer model-level `gna_source` when different models in the same annotation have different GNA provenance.
+
+Consumers SHOULD determine effective provenance for each model entry by using the model-level `gna_source` when present, otherwise falling back to the annotation-level `gna_source` when present.
+
+Consumers SHOULD treat `gna_source` as a provenance signal indicating the source of the annotation or model contribution, not as a guarantee of correctness.
 
 ### ai_level
 
@@ -255,6 +264,7 @@ The `models` field SHOULD be present when `ai_level` is `assisted`, `augmented`,
 Each model object MAY include the following fields:
 
 - `name`: name of the model
+- `gna_source`: numeric identifier of the GNA responsible for this model contribution, assertion, execution, or enrichment, if different from or more specific than the annotation-level provenance
 - `version`: version of the model, if known
 - `provider`: organization or project providing the model, if applicable
 - `source`: source or execution environment of the model
@@ -334,6 +344,7 @@ The `url` field MAY also be used with other `source` values when it provides a s
               "models": [
                 {
                   "name": "local-summary-model",
+                  "gna_source": 1,
                   "version": "2026-01",
                   "source": "local",
                   "identifier": "sha256:exampledigest"
@@ -347,6 +358,46 @@ The `url` field MAY also be used with other `source` values when it provides a s
   ]
 }
 ~~~
+
+
+### Field-Level Annotation with Model-Level GNA Provenance
+
+~~~json
+{
+  "x_gcve": [
+    {
+      "extensions": {
+        "bcp-05-x-01": {
+          "ai_annotations": [
+            {
+              "scope": "field",
+              "field_name": "x_gcve.extensions.vlai-severity-enrichment",
+              "tags": [
+                "ai-computer-assisted:classification"
+              ],
+              "description": "The field was classified by a model contribution asserted by a specific GNA.",
+              "ai_level": "generated",
+              "review_status": "none",
+              "models": [
+                {
+                  "name": "VLAI Severity",
+                  "gna_source": 1,
+                  "version": "d21514a",
+                  "provider": "CIRCL",
+                  "source": "other",
+                  "identifier": "vlai-severity-classification"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+~~~
+
+In this example, `gna_source` is intentionally placed on the model entry because the GNA provenance applies to the model-derived enrichment rather than to the annotation container as a whole.
 
 ### Explicit No-AI Annotation
 
@@ -394,9 +445,9 @@ Producers SHOULD use taxonomy-aligned tags whenever possible to improve interope
 
 Consumers SHOULD tolerate unknown fields inside the extension to allow future evolution of the data model.
 
-Consumers SHOULD use `gna_source` to distinguish the GNA responsible for the AI annotation from other producers, enrichers, or downstream redistributors of the GCVE record.
+Consumers SHOULD use annotation-level and model-level `gna_source` values to distinguish the GNA responsible for the AI annotation from the GNA responsible for a specific model contribution, enrichment, or assertion.
 
-Consumers SHOULD tolerate missing `gna_source`.
+Consumers SHOULD tolerate missing `gna_source` at either level and SHOULD apply annotation-level `gna_source` as a fallback for model entries without model-level provenance.
 
 Consumers SHOULD also tolerate missing `models` fields when `ai_level` is `assisted`, `augmented`, or `generated`, as some producers may not have access to complete model metadata.
 

--- a/static/schema/csaf/extensions/gcve-bcp-05-x-01_1.0.0.json
+++ b/static/schema/csaf/extensions/gcve-bcp-05-x-01_1.0.0.json
@@ -62,6 +62,7 @@
       "required": ["scope", "ai_level"],
       "properties": {
         "scope": {"enum": ["record", "field"]},
+        "gna_source": {"type": "integer"},
         "field_name": {"type": "string", "minLength": 1},
         "tags": {
           "type": "array",
@@ -101,6 +102,7 @@
       "required": ["name"],
       "properties": {
         "name": {"type": "string", "minLength": 1},
+        "gna_source": {"type": "integer"},
         "version": {"type": "string", "minLength": 1},
         "provider": {"type": "string", "minLength": 1},
         "source": {"enum": ["ollama", "huggingface", "local", "other"]},


### PR DESCRIPTION
### Motivation
- Clarify provenance semantics so GNA attribution can be expressed both for an annotation as a whole and for individual model contributions when different GNAs provide or run models.

### Description
- Bump BCP-05-X-01 to `version 1.2` and update the publication date to `2026-06-14` in the extension document at `content/bcp/extension/gcve-bcp-05-x-01.md`.
- Allow `gna_source` as an optional field at the AI-annotation level and add an optional `gna_source` to each `model` entry with documented override and fallback semantics so model-level provenance can override the annotation-level default.
- Add a new example showing a field-level annotation where `gna_source` is placed on a model entry (VLAI severity enrichment) to demonstrate the multi-GNA scenario.
- Update the CSAF extension schema at `static/schema/csaf/extensions/gcve-bcp-05-x-01_1.0.0.json` to permit `gna_source` in both the `aiAnnotation` object and the `model` object.

### Testing
- `git diff --check` was run and reported no whitespace or diff errors.
- JSON schema was validated with `python3 -m json.tool static/schema/csaf/extensions/gcve-bcp-05-x-01_1.0.0.json` and the file is syntactically valid.
- Site build command `hugo --gc --minify` was attempted but not run successfully because `hugo` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ea6ccc21883248499626b858bf1b1)