### PR TITLE
Make homepage GNA stat card link to /gna/

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -17,7 +17,7 @@ toc: false
     <div class="gcve-hero-panel" aria-label="GCVE at a glance">
       <img src="/logos/gcve.png" alt="GCVE logo" />
       <div class="gcve-stat-grid">
-        <div class="gcve-stat"><strong>GNA</strong><span>Independent numbering authorities</span></div>
+        <a class="gcve-stat" href="/gna/" aria-label="Open the official GNA directory"><strong>GNA</strong><span>Independent numbering authorities</span></a>
         <a class="gcve-stat" href="/bcp/" aria-label="Open GCVE Best Current Practices"><strong>BCP</strong><span>Open best current practices</span></a>
         <div class="gcve-stat"><strong>JSON</strong><span>Machine-readable directory</span></div>
         <div class="gcve-stat">Community-lead coordination</div>


### PR DESCRIPTION
### Motivation
- Make the homepage "GNA / Independent numbering authorities" stat card a clickable link to the official GNA directory to improve discoverability and accessibility.

### Description
- Replace the non-interactive GNA stat `<div>` with an `<a>` element linking to `/gna/` and add `aria-label="Open the official GNA directory"` in `content/_index.md`.

### Testing
- Ran `test -e content/gna.md || test -e content/gna/_index.md`, which succeeded.
- Attempted `hugo --minify` to build the site, which failed because the `hugo` binary is not present in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3c1d43a02c832598d70ecf6e8ab04d)