### PR TITLE
Improve homepage GCVE card readability

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -396,7 +396,7 @@ body {
 
 .gcve-hero-grid {
   display: grid;
-  grid-template-columns: minmax(0, 1.25fr) minmax(16rem, 0.75fr);
+  grid-template-columns: minmax(0, 1.15fr) minmax(20rem, 0.85fr);
   gap: clamp(1.5rem, 4vw, 4rem);
   align-items: center;
 }
@@ -490,7 +490,9 @@ body {
 
 .gcve-hero-panel {
   position: relative;
-  padding: 1.25rem;
+  width: min(100%, 26rem);
+  justify-self: end;
+  padding: clamp(1.35rem, 2.4vw, 1.75rem);
   border: 1px solid var(--gcve-border);
   border-radius: 1.5rem;
   background: var(--gcve-card);
@@ -499,19 +501,20 @@ body {
 }
 
 .gcve-hero-panel img {
-  width: min(100%, 320px);
-  margin: 0 auto 1rem;
+  width: min(100%, 360px);
+  margin: 0 auto 1.25rem;
   display: block;
 }
 
 .gcve-stat-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.75rem;
+  gap: 0.95rem;
 }
 
 .gcve-stat {
-  padding: 1rem;
+  min-height: 8.25rem;
+  padding: 1.15rem;
   border: 1px solid rgba(38, 100, 255, 0.11);
   border-radius: 1rem;
   background: rgba(255, 255, 255, 0.58);
@@ -545,7 +548,7 @@ body {
 .gcve-stat strong {
   display: block;
   color: var(--gcve-ink);
-  font-size: 1.4rem;
+  font-size: clamp(1.45rem, 2.2vw, 1.75rem);
   line-height: 1;
 }
 
@@ -553,8 +556,8 @@ body {
   display: block;
   margin-top: 0.35rem;
   color: var(--gcve-muted);
-  font-size: 0.85rem;
-  line-height: 1.35;
+  font-size: clamp(0.92rem, 1.2vw, 1rem);
+  line-height: 1.45;
 }
 
 .gcve-section-intro {
@@ -637,6 +640,8 @@ body {
 
   .gcve-hero-panel {
     order: -1;
+    justify-self: stretch;
+    width: 100%;
   }
 
   .gcve-hero h1 {

--- a/content/_index.md
+++ b/content/_index.md
@@ -20,7 +20,7 @@ toc: false
         <a class="gcve-stat" href="/gna/" aria-label="Open the official GNA directory"><strong>GNA</strong><span>Independent numbering authorities</span></a>
         <a class="gcve-stat" href="/bcp/" aria-label="Open GCVE Best Current Practices"><strong>BCP</strong><span>Open best current practices</span></a>
         <div class="gcve-stat"><strong>JSON</strong><span>Machine-readable directory</span></div>
-        <div class="gcve-stat">Community-lead coordination</div>
+        <div class="gcve-stat"><strong>Open</strong><span>Community-led coordination</span></div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
### Motivation
- The homepage GCVE card’s right column and the four stat boxes were visually cramped and hard to scan at a glance. 
- The GCVE logo and stat text sizes needed to be increased so the information is legible across desktop and mobile breakpoints. 
- The community tile lacked consistent structure and an accessible heading/body pattern used by the other tiles.

### Description
- Adjusts the hero grid proportions via `grid-template-columns` to give the right column more room and increase the card width in `assets/css/custom.css`. 
- Enlarges the card content by adding `width: min(100%, 26rem)`, `justify-self: end`, and responsive padding `padding: clamp(...)` to `.gcve-hero-panel`, and increases the logo max width. 
- Improves stat box spacing and typography by increasing `gap`, adding `min-height` to `.gcve-stat`, and switching to responsive font sizes using `clamp()` for `.gcve-stat strong` and `.gcve-stat span` in `assets/css/custom.css`. 
- Standardises the fourth tile markup and fixes copy to “Community-led coordination” in `content/_index.md` so it matches the heading/body structure of the other tiles.

### Testing
- Attempted site build with `go run github.com/gohugoio/hugo@latest --minify`, which failed due to the Go proxy returning `Forbidden`, preventing a full automated build verification. 
- No other automated tests were run locally due to the blocked Hugo build and the environment constraint.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3c1ec895c48325a5d84e5702c34bdc)