### PR TITLE
Fix homepage hero overlap by adjusting grid and sizing

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -396,7 +396,7 @@ body {
 
 .gcve-hero-grid {
   display: grid;
-  grid-template-columns: minmax(0, 1.15fr) minmax(20rem, 0.85fr);
+  grid-template-columns: minmax(0, 0.95fr) minmax(22rem, 0.8fr);
   gap: clamp(1.5rem, 4vw, 4rem);
   align-items: center;
 }
@@ -428,7 +428,7 @@ body {
   color: var(--gcve-ink);
   overflow-wrap: normal;
   word-break: normal;
-  font-size: clamp(3rem, 6vw, 5.6rem);
+  font-size: clamp(2.75rem, 5.2vw, 4.9rem);
   line-height: 0.92;
   letter-spacing: -0.075em;
 }
@@ -490,7 +490,7 @@ body {
 
 .gcve-hero-panel {
   position: relative;
-  width: min(100%, 26rem);
+  width: min(100%, 28rem);
   justify-self: end;
   padding: clamp(1.35rem, 2.4vw, 1.75rem);
   border: 1px solid var(--gcve-border);
@@ -509,12 +509,12 @@ body {
 .gcve-stat-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.95rem;
+  gap: clamp(0.85rem, 1.6vw, 1rem);
 }
 
 .gcve-stat {
   min-height: 8.25rem;
-  padding: 1.15rem;
+  padding: clamp(0.9rem, 1.8vw, 1.15rem);
   border: 1px solid rgba(38, 100, 255, 0.11);
   border-radius: 1rem;
   background: rgba(255, 255, 255, 0.58);
@@ -556,7 +556,7 @@ body {
   display: block;
   margin-top: 0.35rem;
   color: var(--gcve-muted);
-  font-size: clamp(0.92rem, 1.2vw, 1rem);
+  font-size: clamp(0.9rem, 1.05vw, 1rem);
   line-height: 1.45;
 }
 


### PR DESCRIPTION
### Motivation
- The homepage hero title was colliding with the adjacent hero card at wider viewports, causing the text to appear hidden or wrap awkwardly.
- Improve horizontal separation and responsive scaling so the headline and visual card do not compete for space.

### Description
- Narrow the left hero column and widen the right card by changing `.gcve-hero-grid` from `minmax(0, 1.15fr) minmax(20rem, 0.85fr)` to `minmax(0, 0.95fr) minmax(22rem, 0.8fr)` in `assets/css/custom.css`.
- Reduce the hero title maximum responsive size by changing the `h1` clamp from `clamp(3rem, 6vw, 5.6rem)` to `clamp(2.75rem, 5.2vw, 4.9rem)` to prevent overflow under the card.
- Increase the hero panel width to `min(100%, 28rem)` so the card has more room and reduce cramped layout.
- Make stat-card spacing and typography more responsive by adjusting `.gcve-stat-grid` gap, `.gcve-stat` padding, and `.gcve-stat span` font-size to use `clamp()` values.

### Testing
- Ran `git diff --check` which completed without reported whitespace or syntax errors.
- Attempted `hugo --minify` but it could not run because the `hugo` binary is not installed in the environment, so site build could not be validated here.
- Attempted `go install github.com/gohugoio/hugo@latest` but installation failed due to a blocked Go proxy request in the environment, so the Hugo binary could not be installed for local build testing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3c1ffa31cc8325acb27068174d8341)