### PR TITLE
Shift homepage GCVE card right to avoid heading overlap

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -506,6 +506,12 @@ body {
   display: block;
 }
 
+@media (min-width: 769px) {
+  .gcve-home-hero .gcve-hero-panel {
+    transform: translateX(clamp(1.25rem, 4vw, 3rem));
+  }
+}
+
 .gcve-stat-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/content/_index.md
+++ b/content/_index.md
@@ -3,7 +3,7 @@ title: "GCVE initiative - Global CVE Allocation System"
 toc: false
 ---
 
-<section class="gcve-hero">
+<section class="gcve-hero gcve-home-hero">
   <div class="gcve-hero-grid">
     <div>
       <p class="gcve-eyebrow">Decentralized vulnerability identifiers</p>


### PR DESCRIPTION
### Motivation
- The GCVE homepage hero card partially overlaps the “Allocation” heading on larger viewports, so the visual should be shifted right to avoid hiding text.

### Description
- Add a homepage-scoped class by changing the hero section to `class="gcve-hero gcve-home-hero"` in `content/_index.md` to target only the homepage.
- Add a CSS rule in `assets/css/custom.css` under a `@media (min-width: 769px)` query to translate the `.gcve-hero-panel` right using `transform: translateX(clamp(1.25rem, 4vw, 3rem));` for the `gcve-home-hero` scope.

### Testing
- Ran `git diff --check` which produced no spacing or diff-check errors (success).
- Attempted to run `hugo` but the `hugo` executable is not available in this environment (could not run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a3c212fc9dc8325b289b0156be0bc6f)