### PR TITLE
Add KEV Source Index format and schema, bump BCP-07 to v2.1, and add CIRCL bcp_07_url

### DIFF
--- a/content/bcp/gcve-bcp-07.md
+++ b/content/bcp/gcve-bcp-07.md
@@ -6,7 +6,7 @@ title: GCVE-BCP-07 - Known Exploited Vulnerability - KEV Assertion Format
 
 ![](https://gcve.eu/logos/gcve.png)
 
-- **Version**: 2.0
+- **Version**: 2.1
 - **Status**: Published (for [Public Review](https://discourse.ossbase.org/t/kev-known-exploited-vulnerabilities-potential-format-bcp-07/744))
 - **Date**: 2026-03-10
 - **Authors**: GCVE Working Group
@@ -372,6 +372,180 @@ The confidence **SHALL** come from the following confidence evaluation table to 
 ##### `gcve.object_uuid`
   - **Type:** string
   - **Description:** UUID of the assertion associated with this evidence in the GCVE ecosystem.
+
+
+## KEV Source Index Format
+
+BCP-07 describes individual KEV assertions, but implementers also need a way to discover which organisations publish KEV catalogues and where their machine-readable feeds are located. The GCVE initiative publishes a non-mandatory KEV source index at [https://gcve.eu/dist/references.json](https://gcve.eu/dist/references.json) and maintains the source file at [https://github.com/gcve-eu/gcve.eu/blob/main/static/dist/references.json](https://github.com/gcve-eu/gcve.eu/blob/main/static/dist/references.json).
+
+The index is a catalogue of KEV catalogues. It is not authoritative for the content of any listed catalogue and it is not required for a producer to publish BCP-07 KEV assertions. Its purpose is to facilitate discovery, correlation, and stable attribution of KEV catalogues, especially where `gcve.origin_uuid` or `evidence[].gcve.origin_uuid` values need to be resolved to a known source.
+
+### Index Object
+
+The index is a single JSON object (ECMA 404) with a `kev` array. Each item in the array describes one KEV catalogue or source.
+
+~~~json
+{
+  "kev": [
+    {
+      "uuid": "1a89b78e-f703-45f3-bb86-59eb712668bd",
+      "short_name": "CIRCL",
+      "gcve_gna_id": 1,
+      "url": "https://vulnerability.circl.lu/known-exploited-vulnerabilities-catalog",
+      "automation_url": "https://vulnerability.circl.lu/api/kev/?vulnerability_lookup_origin=1a89b78e-f703-45f3-bb86-59eb712668bd",
+      "bcp_07_url": "https://vulnerability.circl.lu/api/kev/bcp-07/?vulnerability_lookup_origin=1a89b78e-f703-45f3-bb86-59eb712668bd",
+      "description": "CIRCL provides a known-exploited vulnerability catalog and supports the different status reasons described in GCVE BCP-07.",
+      "meta": {
+        "license": "CC-BY-4.0"
+      }
+    }
+  ]
+}
+~~~
+
+### Index Field Description
+
+#### `kev` Array
+
+- **Type:** array
+- **Required:** yes
+- **Description:** Collection of KEV catalogue source descriptions.
+
+#### `kev[].uuid`
+
+- **Type:** string (UUID)
+- **Required:** yes
+- **Description:** Stable UUID identifying the KEV catalogue source. When a BCP-07 assertion uses `gcve.origin_uuid` or `evidence[].gcve.origin_uuid`, the value should match this UUID where the source is listed in the index.
+
+#### `kev[].short_name`
+
+- **Type:** string
+- **Required:** yes
+- **Description:** Short human-readable name for the KEV catalogue source.
+
+#### `kev[].gcve_gna_id`
+
+- **Type:** number (0–65535)
+- **Required:** no
+- **Description:** GNA ID associated with the source, when the source is a GCVE Numbering Authority or otherwise has an assigned GNA identifier.
+
+#### `kev[].url`
+
+- **Type:** string (URI)
+- **Required:** yes
+- **Description:** Human-facing URL for the KEV catalogue or source.
+
+#### `kev[].automation_url`
+
+- **Type:** string (URI)
+- **Required:** no
+- **Description:** Machine-readable URL for the source catalogue in its native or preferred automation format. This field may point to a format other than BCP-07.
+
+#### `kev[].bcp_07_url`
+
+- **Type:** string (URI)
+- **Required:** no
+- **Description:** Machine-readable URL where the KEV data can be retrieved in BCP-07 format. This field is optional because not every KEV source publishes BCP-07 directly. When present, consumers can prefer this URL over `automation_url` when they specifically need BCP-07 assertions.
+
+#### `kev[].description`
+
+- **Type:** string
+- **Required:** no
+- **Description:** Human-readable description of the KEV catalogue source.
+
+#### `kev[].meta`
+
+- **Type:** object
+- **Required:** no
+- **Description:** Optional metadata about the KEV catalogue source. This object is intentionally extensible to allow source-specific metadata without changing the core index format.
+
+##### `kev[].meta.license`
+
+- **Type:** string
+- **Required:** no
+- **Description:** Licence identifier for the KEV catalogue when available. SPDX identifiers SHOULD be used where an SPDX identifier exists, for example `CC-BY-4.0`, `CC0-1.0`, or `Apache-2.0`.
+
+### JSON Schema for the KEV Source Index
+
+~~~json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://gcve.eu/schemas/bcp-07-kev-source-index.schema.json",
+  "title": "GCVE-BCP-07 KEV Source Index",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "kev"
+  ],
+  "properties": {
+    "kev": {
+      "type": "array",
+      "description": "Collection of KEV catalogue source descriptions.",
+      "items": {
+        "$ref": "#/$defs/kevSource"
+      }
+    }
+  },
+  "$defs": {
+    "kevSource": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "uuid",
+        "short_name",
+        "url"
+      ],
+      "properties": {
+        "uuid": {
+          "type": "string",
+          "format": "uuid",
+          "description": "Stable UUID identifying the KEV catalogue source."
+        },
+        "short_name": {
+          "type": "string",
+          "description": "Short human-readable name for the KEV catalogue source."
+        },
+        "gcve_gna_id": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 65535,
+          "description": "GNA ID associated with the source, when available."
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Human-facing URL for the KEV catalogue or source."
+        },
+        "automation_url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Machine-readable URL for the source catalogue in its native or preferred automation format."
+        },
+        "bcp_07_url": {
+          "type": "string",
+          "format": "uri",
+          "description": "Machine-readable URL where KEV data can be retrieved in BCP-07 format."
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of the KEV catalogue source."
+        },
+        "meta": {
+          "type": "object",
+          "description": "Optional extensible metadata about the KEV catalogue source.",
+          "additionalProperties": true,
+          "properties": {
+            "license": {
+              "type": "string",
+              "description": "Licence identifier for the KEV catalogue; use an SPDX identifier when available."
+            }
+          }
+        }
+      }
+    }
+  }
+}
+~~~
 
 ### JSON Schema
 

--- a/static/dist/references.json
+++ b/static/dist/references.json
@@ -13,7 +13,8 @@
       "gcve_gna_id": 1,
       "url": "https://vulnerability.circl.lu/known-exploited-vulnerabilities-catalog",
       "automation_url": "https://vulnerability.circl.lu/api/kev/?vulnerability_lookup_origin=1a89b78e-f703-45f3-bb86-59eb712668bd",
-      "description": "CIRCL provides a known-exploited vulnerability catalog and supports the different status reasons described in GCVE BCP-07."
+      "description": "CIRCL provides a known-exploited vulnerability catalog and supports the different status reasons described in GCVE BCP-07.",
+      "bcp_07_url": "https://vulnerability.circl.lu/api/kev/?vulnerability_lookup_origin=1a89b78e-f703-45f3-bb86-59eb712668bd"
     },
     {
       "uuid": "cce329bf-df49-4c6e-a027-80be2e6483bd",


### PR DESCRIPTION
### Motivation

- Provide a discoverable, machine-readable index of KEV catalogue sources to support discovery, stable attribution, and resolution of `gcve.origin_uuid` values. 
- Clarify that KEV assertions (BCP-07) remain independent from discovery metadata and provide a non-authoritative catalogue for implementers. 
- Ensure the published references include a BCP-07-specific endpoint where available for easier consumer preference.

### Description

- Bumped BCP-07 document version from `2.0` to `2.1` in `content/bcp/gcve-bcp-07.md` and added a new `KEV Source Index Format` section that describes the index, provides an example, and defines the JSON Schema for the index at `$id` `https://gcve.eu/schemas/bcp-07-kev-source-index.schema.json`.
- Added a full JSON Schema for the KEV source index including definitions for `kev[].uuid`, `kev[].short_name`, `kev[].gcve_gna_id`, `kev[].url`, `kev[].automation_url`, `kev[].bcp_07_url`, `kev[].description`, and `kev[].meta`.
- Updated `static/dist/references.json` to include a `bcp_07_url` for the CIRCL entry so consumers can prefer a BCP-07 feed when available.

### Testing

- Validated the example KEV source index against the newly added index JSON Schema and the validation succeeded.
- Validated the updated `static/dist/references.json` entry for CIRCL against the index schema and validation succeeded.
- No additional automated unit tests were added or required for the documentation and schema changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a475bf1d1888325a4be1dafc497ed56)