### PR TITLE
Update GCVE FAQ for current BCP ecosystem

### DIFF
--- a/content/faq.md
+++ b/content/faq.md
@@ -5,127 +5,353 @@ toc: true
 
 # GCVE Frequently Asked Questions (FAQ)
 
-## **Q1: What is GCVE?**
+GCVE is an evolving, community-driven initiative. This FAQ provides a practical overview of the allocation model, publication mechanisms, Best Current Practices (BCPs), software, and public services. For normative or implementation-specific details, consult the [BCP index](/bcp/), the [GNA directory](/gna/), and the individual GNA publication policies.
 
-A: GCVE (Global CVE Allocation System) is a new, decentralized system for identifying and numbering security vulnerabilities. It aims to increase flexibility, scalability, and autonomy for organizations involved in vulnerability management, while remaining compatible with the traditional CVE® system.
+## Core concepts and identifiers
 
-## **Q2: How is GCVE different from the traditional CVE system?**
+### Q1: What is GCVE?
 
-A: The main difference is decentralization. GCVE introduces **GCVE Numbering Authorities (GNAs)**, which are independent entities that can allocate GCVE identifiers without needing blocks pre-allocated from a central authority or adhering strictly to centrally enforced policies. The traditional CVE system typically relies on a more centralized structure for ID allocation and policy.
+GCVE (Global CVE Allocation System) is an open, decentralized approach to identifying, numbering, publishing, and exchanging vulnerability-related information.
 
-## **Q3: What is a GCVE Numbering Authority (GNA)?**
+It is designed to improve flexibility, scalability, resilience, and autonomy while remaining interoperable with the existing CVE ecosystem. GCVE is built around independent **GCVE Numbering Authorities (GNAs)** and machine-readable Best Current Practices.
 
-A: A GNA is an organization approved to assign GCVE identifiers. Each GNA gets a unique numeric ID, which becomes part of the GCVE ID format. GNAs have the autonomy to allocate IDs at their own pace and define their own internal policies for vulnerability identification.
+### Q2: How is GCVE different from the traditional CVE system?
 
-## **Q4: Does GCVE replace existing CVE IDs? How does compatibility work?**
+The primary difference is decentralization.
 
-A: No, GCVE does not replace existing CVE IDs. It's designed to be backward-compatible. All existing and future standard CVE IDs are represented within the GCVE system using the reserved `GNA ID 0`. For example, `CVE-2023-40224` can be represented as `GCVE-0-2023-40224`.
+In GCVE, each GNA:
 
-## **Q5: What is the format of a GCVE identifier?**
+- receives a unique numeric identifier;
+- allocates identifiers within its own namespace;
+- defines and publishes its operational scope and policies;
+- can publish vulnerability information directly from its own infrastructure.
 
-The GCVE identifier typically follows a traditional four-part format:
+GCVE does not require a central authority to pre-allocate identifier blocks or adjudicate every disagreement. Consumers can choose which GNAs and data sources they trust and synchronize.
 
-`GCVE-<GNA-ID>-<YEAR>-<UNIQUE-ID>`
+### Q3: What is a GCVE Numbering Authority (GNA)?
 
-This format is recommended because it is consistent with models used in other vulnerability identification systems.  
+A GNA is an entity authorized to allocate GCVE identifiers and publish associated records according to its own scope, governance, disclosure model, and data model.
 
-However, GNAs retain the flexibility to use alternative formats, especially if they already maintain their own identifier schemes.  
+A GNA can be a vendor, an open source project, a CSIRT or CERT, a vulnerability database, a research organization, or another eligible vulnerability publisher. Each GNA is assigned a unique numeric ID that forms part of its GCVE identifiers.
 
-### Format Breakdown
+### Q4: Does GCVE replace existing CVE IDs? How does compatibility work?
 
-| Field       | Description                                                         |
-|-------------|---------------------------------------------------------------------|
-| `GCVE`      | Prefix indicating a Global CVE ID |
-| `GNA ID`    | Unique identifier for the GCVE Numbering Authority                  |
-| `YEAR`      | The year of disclosure or allocation                                |
-| `UNIQUE ID` | A GNA-assigned identifier that must be unique for vulnerability allocated at the GNA |                 
+No. GCVE does not replace CVE.
 
-If a GNA chooses to use an alternative format, it must still follow this general prefix structure:
+The reserved **GNA ID 0** maps CVE identifiers into the GCVE namespace. For example:
 
-`GCVE-<GNA-ID>-<GNA-VALUE>`
+- `CVE-2023-40224`
+- `GCVE-0-2023-40224`
 
-The `GNA-VALUE` should be composed of valid 7-bit characters, excluding unprintable control codes and spaces.
+These two forms refer to the same CVE identifier. The mapping provides a consistent namespace for correlation, but software may still need explicit support for parsing and displaying the `GCVE-0-...` syntax.
 
-The following regular expression can be used to validate a GCVE Identifier: `^GCVE-[0-9]+-[\x22-\x7E]+$`.
+GCVE records can also reference CVE, GHSA, vendor advisory, or other vulnerability identifiers through explicit relationships.
 
-When defining a generic GNA value, GNAs should keep in mind the following considerations:
+### Q5: What is the format of a GCVE identifier?
 
-- The practicality and readability of the identifier (even if technically valid).
-- Facilitating sharing and improving the visibility of the identifier.
+The recommended format is:
 
-The GCVE standard allows a certain level of flexibility in how information is conveyed, but it is strongly recommended to maintain a reasonable degree of readability.
+```text
+GCVE-<GNA-ID>-<YEAR>-<UNIQUE-ID>
+```
 
-For more details, [GCVE-BCP-04 - Recommendations and Best Practices for ID Allocation](/bcp/gcve-bcp-04/).
+Example:
 
-## **Q6: What are the main benefits of using the GCVE system?**
+```text
+GCVE-1-2026-12345
+```
 
-A: The key benefits include:
-*   **Decentralized Allocation:** GNAs manage their own ID assignments.
-*   **Policy Flexibility:** GNAs can operate under their own guidelines.
-*   **Scalability:** Helps avoid bottlenecks found in centralized systems.
-*   **Compatibility:** Seamlessly integrates existing CVEs via `GNA ID 0`.
+| Field | Description |
+|---|---|
+| `GCVE` | Prefix identifying the GCVE namespace |
+| `GNA-ID` | Numeric identifier of the assigning GNA |
+| `YEAR` | Year used by the assigning GNA |
+| `UNIQUE-ID` | Value that is unique within the GNA namespace |
 
-## **Q7: Who is the first GNA using this model?**
+GNAs may use an alternative value structure when needed:
 
-A: CIRCL (Computer Incident Response Center Luxembourg) is the first organization assigned a GNA ID (`GNA ID 1`) to use the new GCVE allocation model. `GNA ID 0` is reserved for mapping existing CVEs.
+```text
+GCVE-<GNA-ID>-<GNA-VALUE>
+```
 
-## **Q8: Where can I find the official list of GNAs?**
+The value must use printable 7-bit characters without spaces. Implementations should support identifiers up to 255 characters. The generic validation expression is:
 
-A: The official registry, including a list of GNAs and their IDs, is maintained at [https://gcve.eu](https://gcve.eu) and published as JSON at the following location [https://gcve.eu/dist/gcve.json](https://gcve.eu/dist/gcve.json).
+```text
+^GCVE-[0-9]+-[\x22-\x7E]+$
+```
 
-## **Q9: Is there software that supports GCVE?**
+See [GCVE-BCP-04 — Recommendations and Best Practices for ID Allocation](/bcp/gcve-bcp-04/).
 
-A: Yes. Any software handling standard CVEs can implicitly handle GCVE IDs with `GNA ID 0`. Additionally, the [vulnerability-lookup](https://www.vulnerability-lookup.org) tool supports the full GNA allocation process and GCVE format.
+### Q6: What are the main benefits of using the GCVE system?
 
-![GCVE integrated in a CVE view in vulnerability-lookup](/images/usage.png)
+The main benefits are:
 
-## **Q10: How can my organization become a GNA?**
+- **Autonomy:** GNAs allocate identifiers and operate according to their own declared policies.
+- **Distributed publication:** vulnerability records can be published directly by their producers.
+- **Interoperability:** CVE records and other identifiers can be mapped and cross-referenced.
+- **Resilience:** the ecosystem does not depend on a single publication database or workflow.
+- **Multiple perspectives:** complementary, updated, disputed, or constituency-specific records can coexist.
+- **Extensibility:** BCPs define formats for records, relationships, KEV assertions, CPE data, AI provenance, and other operational needs.
+- **Open implementation:** the reference software, schemas, clients, and supporting tools are open source.
 
-A: If you are an existing CNA (CVE Numbering Authority) or an [organization falling into the eligibility criteria](https://gcve.eu/about/#eligibility-and-process-to-obtain-a-gna-id), you can send an email to `gna@gcve.eu` with your CNA name. You will need to provide information about your organization, like its short name and full name, similar to the format used in the GNA JSON directory file available on gcve.eu.
+## GNAs and participation
 
-## **Q11: What information is available about GNAs on the gcve.eu website?**
+### Q7: Who is the first GNA using this model?
 
-A: A JSON is [available](https://gcve.eu/dist/gcve.json), containing details for each registered GNA. This includes their unique `id` (GNA ID), `short_name`, `full_name`, and potentially URLs for their specific GCVE data, API, dumps, and allocation process (like `gcve_url`, `gcve_api`, `gcve_dump`, `gcve_allocation`).
+**CIRCL (Computer Incident Response Center Luxembourg)** is GNA 1 and was the first organization to operate the GCVE allocation model.
 
-## **Q12: What is the relationship between the open source vulnerability-lookup project, the EUVD (European Union Vulnerability Database), and GCVE.eu?**
+GNA 0 is reserved for CVE mapping and is not an independent allocator.
 
-Europe has a strong cybersecurity network (thanks to the [EU CSIRTs network](https://csirtsnetwork.eu/)). CIRCL developed the open source [vulnerability-lookup](https://www.vulnerability-lookup.org/) project to address past challenges in collecting diverse sources, ensuring both diversity and stability. The project is co-funded by the European DEP program (NGSOTI) and Luxembourg to support national activities under NIS2.
+### Q8: Where can I find the official list of GNAs?
 
-While maintaining the project, CIRCL identified many shortcomings in ID allocation and correlation when using and operating the [vulnerability.circl.lu](https://vulnerability.circl.lu/) instance(s). To address this, we created [GCVE.eu](https://gcve.eu) as a resilient ID allocation system, designed to ensure autonomy from various vulnerability publishers and improve stability in identifier correlation.
+The human-readable directory is available on the [GNA directory page](/gna/).
 
-As part of the unified NIS2 activities within the European Union, ENISA — which leads the [EU CSIRTs network](https://csirtsnetwork.eu/) — operates the [EUVD](https://euvd.enisa.europa.eu/), which relies on the [vulnerability-lookup](https://euvd.enisa.europa.eu/faq) software. There is a strong collaboration between CIRCL and ENISA on this topic to improve coordination, tooling, and data quality across the EU vulnerability ecosystem.
+The machine-readable directory is published at:
 
-## **Q13: Is the JSON file distributed by GCVE signed, and how can the signature be verified?**
+- [GCVE GNA directory JSON](/dist/gcve.json)
+- [Directory signature](/dist/gcve.json.sigsha512)
+- [GCVE public signing key](/dist/key/public.pem)
 
-The [JSON file](https://gcve.eu/dist/gcve.json) distributed by GCVE is [digitally signed](https://gcve.eu/dist/gcve.json.sigsha512) using an RSA public key with SHA-512.
+The JSON directory is the discovery mechanism for GNA metadata, publication endpoints, APIs, dumps, and allocation services.
 
-The public key is available at multiple locations:
+### Q9: Is there software that supports GCVE?
 
-- Via HTTP: [https://gcve.eu/dist/key/public.pem](https://gcve.eu/dist/key/public.pem)
-- Via DNS: `dig -t TXT _key.gcve.eu`
-- On GitHub: [https://raw.githubusercontent.com/gcve-eu/gcve.eu-directory/refs/heads/main/key/public.pem](https://raw.githubusercontent.com/gcve-eu/gcve.eu-directory/refs/heads/main/key/public.pem)
+Yes. The open-source [software page](/software/) lists reference and supporting implementations, including:
 
-## **Q14: How does decentralized publication work?**
+- **[Vulnerability-Lookup](https://www.vulnerability-lookup.org/):** reference implementation for operating a GNA, allocating identifiers, publishing records, synchronizing sources, and performing vulnerability lookup.
+- **gcve:** Python library and command-line client for retrieving and verifying the GNA directory.
+- **bcp-validator:** JSON Schemas and validators for GCVE BCP data structures.
+- **cpe-editor:** collaborative vendor, product, CPE, metadata, and relationship curation.
+- **gcve-eu-kev:** conversion tooling for BCP-07 KEV assertions.
+- **gcve-eu-ai-extension:** tooling for AI-assisted enrichment with BCP-05-X-01 provenance metadata.
 
-[Vulnerability-Lookup](https://www.vulnerability-lookup.org/) is a reference open-source software that includes a functional model for using the GCVE.eu GNA directory. It allows each user of Vulnerability-Lookup to select which GNAs to gather vulnerability information from.
+![GCVE integrated in a CVE view in Vulnerability-Lookup](/images/usage.png)
 
-This enables GNAs to directly publish their vulnerability information without relying on a centralized system.
+### Q10: How can my organization become a GNA?
 
-There is no complex technology or software involved, it's a standard ReST API, implemented and documented as a Best Current Practice ([BCP-03](/bcp/gcve-bcp-03/)), which can be easily reimplemented by other software solutions.
+The current eligibility criteria include:
+
+- an existing CNA recognized by the CVE Program;
+- a CSIRT or CERT listed by FIRST, participating in the EU CSIRTs Network, or belonging to TF-CSIRT;
+- a software, hardware, or service provider that regularly publishes vulnerabilities affecting its own products or services and has an official CPE vendor name;
+- another organization with a public vulnerability disclosure policy and a public source publishing new vulnerability records in [GCVE-BCP-05 format](/bcp/gcve-bcp-05/).
+
+Send a request to `gna@gcve.eu` with the organization name and the directory metadata described on the [About page](/about/#eligibility-and-process-to-obtain-a-gna-id).
+
+You do not need to be a GNA to consume GCVE data, use the software, participate in BCP discussions, or run a local Vulnerability-Lookup instance. A GNA ID is required to allocate identifiers in an official GCVE namespace.
+
+### Q11: What information is available about GNAs on the gcve.eu website?
+
+The [GCVE directory JSON](/dist/gcve.json) includes the GNA ID, short name, full name, timestamps, and optional operational metadata such as:
+
+- `cpe_vendor_name`
+- `gcve_url`
+- `gcve_api`
+- `gcve_dump`
+- `gcve_allocation`
+- `gcve_pull_api`
+
+Not every GNA exposes every field. A GNA may use different publication mechanisms depending on its operational model.
+
+## Ecosystem, publication, and trust
+
+### Q12: What is the relationship between the open source vulnerability-lookup project, the EUVD (European Union Vulnerability Database), and GCVE.eu?
+
+**Vulnerability-Lookup** is an open-source vulnerability-management and publication platform developed and maintained by CIRCL. It is the reference implementation for several GCVE workflows, including GNA operations, decentralized publication, synchronization, and record enrichment.
+
+**GCVE.eu** defines the decentralized identifier, directory, publication, and BCP ecosystem. It is a separate initiative led by CIRCL and shaped through open community contributions.
+
+**db.gcve.eu** is a public Vulnerability-Lookup instance that aggregates and correlates GCVE/GNA and other public vulnerability sources.
+
+The **European Union Vulnerability Database (EUVD)** is operated by ENISA. Vulnerability-Lookup has also been used as open-source infrastructure in the broader European vulnerability ecosystem. GCVE, EUVD, and Vulnerability-Lookup have distinct roles, even where their tooling, data, and operational communities interact.
+
+### Q13: Is the JSON file distributed by GCVE signed, and how can the signature be verified?
+
+Yes. The GNA directory is signed with an RSA key and SHA-512.
+
+The required files are:
+
+- [Directory JSON](/dist/gcve.json)
+- [Base64-encoded SHA-512 signature](/dist/gcve.json.sigsha512)
+- [Public key](/dist/key/public.pem)
+
+The public key is also published through the `_key.gcve.eu` DNS TXT record and in the GCVE directory repository.
+
+Consumers should verify the signature before trusting or automatically ingesting directory content. See [GCVE-BCP-01 — Signature Verification of the Directory File](/bcp/gcve-bcp-01/) for the verification procedure and tooling.
+
+### Q14: How does decentralized publication work?
+
+Each GNA controls its own publication infrastructure. The GCVE directory advertises the GNA entry points, and consumers decide which sources to retrieve and trust.
+
+[GCVE-BCP-03](/bcp/gcve-bcp-03/) defines two lightweight HTTP publication mechanisms:
+
+- a REST endpoint, normally exposed under `/api/gcve/publication`;
+- a static newline-delimited JSON dump, normally exposed as `/dumps/gna-<GNA-ID>.ndjson`.
+
+Published records use the [GCVE-BCP-05 format](/bcp/gcve-bcp-05/). Vulnerability-Lookup provides the reference implementation for both publishing and collecting GNA records.
 
 ![Overview of the GCVE GNA publication model](/images/gcve-eu-network.png)
 
-## **Q15: Do you have any logos for GCVE and the GNA?**
+### Q15: Do you have any logos for GCVE and the GNA?
 
-For GCVE.eu, there are two sets of logos: one set features the generic logos of the GCVE initiative, and the other is for GNAs — GCVE Numbering Authorities. All logos are available at [https://gcve.eu/logo/](/logo), including both bitmap and vector-based formats.
+Yes. The [logo page](/logo/) provides GCVE initiative and GNA logos in bitmap and vector formats.
 
-## **Q16: What is [db.gcve.eu](https://db.gcve.eu/)?**
+### Q16: What is db.gcve.eu?
 
-[db.gcve.eu](https://db.gcve.eu/) is a public and open instance of [vulnerability-lookup](https://vulnerability-lookup.org), providing users with a unified interface to access and correlate vulnerability information from all available GNA sources and other public databases.
+[db.gcve.eu](https://db.gcve.eu/) is a public and open instance of Vulnerability-Lookup. It provides a unified interface for searching, correlating, and exploring vulnerability information from GCVE GNAs and other public sources.
 
-We strongly encourage other organizations, in particular **GCVE Numbering Authorities (GNAs)**, to deploy their own instances in order to publish and manage vulnerabilities in a **distributed, federated, and resilient** manner, in line with the GCVE model.
+It is a useful public service and reference deployment, but it is not intended to become the single authoritative database for GCVE. GNAs and other organizations are encouraged to operate their own publication and collection infrastructure.
 
-## **Q17: How do you deal with disputes?**
+### Q17: How do you deal with disputes?
 
-We are not the CVE program. It's just fine to have disagreements.
+GCVE does not attempt to eliminate disagreement through a central adjudication authority. Different GNAs may reach different conclusions about validity, impact, affected products, severity, exploitation, or remediation.
 
+The model handles disagreement through:
+
+- source attribution;
+- independently published records and assertions;
+- explicit cross-references and relationships such as `equal`, `not equal`, `subset`, `superset`, `overlap`, `opposes`, and `not_applicable`;
+- transparent GNA policies and operational metadata;
+- consumer choice over which sources to trust.
+
+Disagreement is therefore represented as structured, attributable information rather than silently overwritten. GNAs should cross-reference related records whenever possible.
+
+## Best Current Practices and extensions
+
+### Q18: What is a GCVE Best Current Practice (BCP), and is it mandatory?
+
+A GCVE BCP is a community-developed document describing recommended formats, procedures, operational principles, or interoperability practices.
+
+BCPs are:
+
+- descriptive rather than centrally imposed;
+- developed through public discussion and review;
+- focused on interoperability, transparency, and trust;
+- living documents that can evolve with implementation experience.
+
+Following a BCP is not universally mandatory, but it is strongly recommended. Individual BCPs may use normative language for implementations claiming compatibility with that specific document. Always check the [BCP index](/bcp/) for the current version and status.
+
+### Q19: Which GCVE BCPs are currently available?
+
+The public BCP series currently covers:
+
+- **[BCP-01](/bcp/gcve-bcp-01/):** signature verification of the GNA directory.
+- **[BCP-02](/bcp/gcve-bcp-02/):** practical vulnerability handling and coordinated disclosure guidance.
+- **[BCP-03](/bcp/gcve-bcp-03/):** decentralized publication and synchronization.
+- **[BCP-04](/bcp/gcve-bcp-04/):** identifier allocation and syntax.
+- **[BCP-05](/bcp/gcve-bcp-05/):** GCVE vulnerability record format.
+- **[BCP-06](/bcp/gcve-bcp-06/):** transparency and evaluation criteria for GNAs.
+- **[BCP-07](/bcp/gcve-bcp-07/):** attributable Known Exploited Vulnerability assertions and source indexes.
+- **[BCP-09](/bcp/gcve-bcp-09/):** scope and semantics of GCVE records.
+- **[BCP-10](/bcp/gcve-bcp-10/):** improved vendor, product, CPE, metadata, and relationship enumeration.
+
+The series also supports extensions, including **[BCP-05-X-01](/bcp/extension/gcve-bcp-05-x-01/)** for AI-assisted vulnerability information annotation.
+
+Some documents are published, some are published for public review, and some remain drafts. The [BCP index](/bcp/) is the source of truth for their current status.
+
+### Q20: What does GCVE-BCP-05 define?
+
+[GCVE-BCP-05](/bcp/gcve-bcp-05/) defines a vulnerability record format derived from the CVE JSON v5 Record Format.
+
+It preserves compatibility with established CVE tooling while adding GCVE-specific metadata such as:
+
+- `vulnId`
+- `recordType`
+- `relationships`
+- extension namespaces
+
+Record types include `advisory`, `update`, `analysis`, `metadata`, `reference`, `comment`, `statement`, `remediation`, `deprecation`, `detection`, `translation`, and `bundle`.
+
+Relationships allow a record to state how it relates to another GCVE, CVE, vendor advisory, or external identifier.
+
+### Q21: Is a GCVE record limited to a traditional vulnerability advisory?
+
+No.
+
+[GCVE-BCP-09](/bcp/gcve-bcp-09/) clarifies that a GCVE record is a GNA-assigned object containing vulnerability-related information. Depending on the GNA model, it may represent:
+
+- a software, hardware, firmware, infrastructure, cloud, or service vulnerability;
+- a clarification or correction;
+- remediation or mitigation guidance;
+- a downstream, product-specific, or deployment-specific impact statement;
+- a correlation or relationship record;
+- other documented vulnerability-related context.
+
+Consumers should interpret a record according to its assigning GNA, `recordType`, declared relationships, and published record model.
+
+### Q22: Can several GCVE records or identifiers refer to the same vulnerability?
+
+Yes. This is an intentional feature of the decentralized model.
+
+Different GNAs may independently identify the same issue, publish complementary context, represent downstream impact, disagree about scope, or add remediation and analytical material. There is no requirement for one globally authoritative record for every vulnerability.
+
+GNAs should use explicit relationships and cross-references so consumers can correlate equivalent, overlapping, narrower, broader, or conflicting records.
+
+### Q23: What is the GCVE Known Exploited Vulnerability format?
+
+[GCVE-BCP-07](/bcp/gcve-bcp-07/) defines a structured format for **KEV assertions**.
+
+A KEV assertion is separate from the vulnerability identity. It expresses who claims that exploitation occurred, when it was observed or asserted, the supporting evidence, scope, and confidence.
+
+Multiple organizations may publish different or even conflicting KEV assertions for the same vulnerability. These assertions are attributable statements, not universal ground truth, and may be revised or withdrawn as evidence changes.
+
+The non-mandatory [KEV source index](/dist/references.json) helps consumers discover KEV catalogues, machine-readable feeds, stable source UUIDs, and available licensing metadata.
+
+### Q24: What is cpe.gcve.eu and how does it relate to BCP-10?
+
+[cpe.gcve.eu](https://cpe.gcve.eu/) is a public collaborative service for browsing and curating vendors, products, CPE entries, metadata, and relationships.
+
+[GCVE-BCP-10](/bcp/gcve-bcp-10/) describes the corresponding improved enumeration model. It retains CPE 2.3 compatibility while adding stable UUIDv5 identifiers, aliases, renames, lifecycle relationships, namespaced metadata, provenance, moderation, and portable synchronization data.
+
+The open-source implementation is available as **cpe-editor**.
+
+### Q25: How does GCVE identify AI-assisted vulnerability information?
+
+[GCVE-BCP-05-X-01](/bcp/extension/gcve-bcp-05-x-01/) defines optional annotations for records or fields created, enriched, transformed, or classified with AI or automated processing.
+
+The extension records information such as:
+
+- whether AI use was assisted, augmented, or generated;
+- which record or field was affected;
+- the model and provider, when known;
+- the responsible GNA;
+- whether the output received no, partial, or full human review;
+- relevant taxonomy-aligned tags.
+
+The objective is transparency and provenance, not an assertion that AI-generated content is authoritative.
+
+### Q26: What is GNA 65530 and the proposed BCP-11?
+
+[GNA 65530 — GCVE-CVE-Extension](/gna/65530/) is reserved for publishing community-proposed extensions or updates associated with existing CVE records.
+
+Its purpose is to provide an additional, machine-readable GCVE channel for proposed corrections, enrichment, CPE information, or other updates when the original CVE record cannot be changed promptly or through the original publisher. Records published through this GNA do **not** overwrite or modify the upstream CVE record.
+
+The related **[BCP-11 proposal](https://discourse.ossbase.org/t/gcve-bcp-11-community-proposed-updates-to-existing-cve-records/1110)** is being developed through the public GCVE discussion process. Until it is formally listed in the BCP index, its status should be considered a public proposal under development.
+
+## Community, data, and reuse
+
+### Q27: How can I contribute to a GCVE BCP or propose a new one?
+
+GCVE uses a transparent and traceable [BCP development process](/process/).
+
+Each BCP or exploratory topic has a dedicated public discussion thread on the GCVE Discourse forum. The discussion captures the problem statement, alternatives, technical trade-offs, feedback, objections, revisions, and eventual consensus.
+
+Contributions are also welcome through open-source implementations, schemas, test data, operational feedback, and participation in the [GCVE community](/who/).
+
+### Q28: Where can I obtain GCVE open data?
+
+The [Open Data page](/opendata/) lists public and machine-readable resources, including:
+
+- Vulnerability-Lookup source dumps;
+- GNA-specific dumps;
+- GCVE enriched records;
+- comments, sightings, bundles, and KEV assertion data;
+- data for research, mirroring, correlation, and automation.
+
+Consumers should preserve source attribution, verify directory signatures, treat automated or AI-assisted enrichment as complementary information, and validate operational decisions against the appropriate vendor or authoritative source.
+
+### Q29: How should I cite GCVE or contact the project?
+
+Use the recommended academic and technical reference on the [Citation page](/citation/).
+
+For GNA requests, email `gna@gcve.eu`. For general questions, community channels, and other contact details, see the [Contact page](/contact/).


### PR DESCRIPTION
## Summary

Refreshes `content/faq.md` to reflect the current GCVE allocation, publication, BCP, software, and open-data ecosystem.

## What changed

- Reworked the FAQ into clearer thematic sections while preserving the existing Q1–Q17 question text anchors, including the Q12 anchor referenced elsewhere on the site.
- Clarified CVE compatibility, GNA autonomy, consumer-selected trust, identifier syntax, decentralized publication, and dispute handling.
- Corrected the previous implication that generic CVE software automatically supports the `GCVE-0-...` syntax.
- Added current software and services: Vulnerability-Lookup, the GCVE client, BCP validator, CPE editor, KEV tooling, AI-extension tooling, `db.gcve.eu`, and `cpe.gcve.eu`.
- Added concise coverage of BCP-01 through BCP-07, BCP-09, BCP-10, and BCP-05-X-01.
- Added dedicated explanations for BCP-05 record types and relationships, BCP-07 KEV assertions and the KEV source index, BCP-09 record scope, BCP-10 CPE curation, and AI provenance annotations.
- Added GNA 65530 and the BCP-11 public proposal for community-proposed updates and extensions to existing CVE records, explicitly stating that these records do not overwrite upstream CVE records.
- Expanded guidance on BCP contribution, open data, citation, and contact channels.

## Validation

- Confirmed the branch is one commit ahead of `main` and changes only `content/faq.md`.
- Verified all question numbers from Q1 to Q29 are present and sequential.
- Re-read the committed Markdown from GitHub to confirm formatting, links, identifier regex, and the preserved Q12 heading.

No Hugo build was run because the change was made through the GitHub connector rather than a local checkout.