### PR TITLE
Fix activities review date range wording

### DIFF
--- a/content/news/2026-08-13-recent-activities.md
+++ b/content/news/2026-08-13-recent-activities.md
@@ -209,4 +209,4 @@ Organisations and projects can participate by:
 - consuming the [open datasets and feeds](https://gcve.eu/opendata/);
 - applying to become a [GCVE Numbering Authority](https://gcve.eu/about/#eligibility-and-process-to-obtain-a-gna-id).
 
-The last eleven weeks have added standards, practical software and new publishers. The next stage is broader implementation: more independent publication endpoints, more interoperable assertions and sightings, and continued feedback from the organisations using GCVE in real vulnerability-handling workflows.
+The period from 26 May through 13 August has added standards, practical software and new publishers. The next stage is broader implementation: more independent publication endpoints, more interoperable assertions and sightings, and continued feedback from the organisations using GCVE in real vulnerability-handling workflows.


### PR DESCRIPTION
### Motivation
- Make the closing sentence of the 2026-08-13 activities review consistent with the explicit date range used earlier by replacing the rounded "last eleven weeks" phrasing with the exact period "26 May through 13 August" in `content/news/2026-08-13-recent-activities.md`.

### Description
- Update a single line in `content/news/2026-08-13-recent-activities.md` to read: "The period from 26 May through 13 August has added standards, practical software and new publishers...".

### Testing
- Ran `git diff --check`, which returned no problems; and attempted `hugo --minify`, which could not run in the environment because `hugo` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a7dddd61e348325a5592fc6fe407bab)