### PR TITLE
GCVE-BCP-07: bump to v2.2 and introduce GCVE KEV Directory + schema changes

### DIFF
--- a/content/bcp/gcve-bcp-07.md
+++ b/content/bcp/gcve-bcp-07.md
@@ -6,9 +6,9 @@ title: GCVE-BCP-07 - Known Exploited Vulnerability - KEV Assertion Format
 
 ![](https://gcve.eu/logos/gcve.png)
 
-- **Version**: 2.1
+- **Version**: 2.2
 - **Status**: Published (for [Public Review](https://discourse.ossbase.org/t/kev-known-exploited-vulnerabilities-potential-format-bcp-07/744))
-- **Date**: 2026-07-03
+- **Date**: 2026-09-01
 - **Authors**: GCVE Working Group
 - **BCP ID**: BCP-07
 
@@ -374,9 +374,16 @@ The confidence **SHALL** come from the following confidence evaluation table to 
   - **Description:** UUID of the assertion associated with this evidence in the GCVE ecosystem.
 
 
-## KEV Source Index Format
+## GCVE KEV Directory and Source Index Format
 
-BCP-07 describes individual KEV assertions, but implementers also need a way to discover which organisations publish KEV catalogues and where their machine-readable feeds are located. The GCVE initiative publishes a non-mandatory KEV source index at [https://gcve.eu/dist/references.json](https://gcve.eu/dist/references.json) and maintains the source file at [https://github.com/gcve-eu/gcve.eu/blob/main/static/dist/references.json](https://github.com/gcve-eu/gcve.eu/blob/main/static/dist/references.json).
+BCP-07 describes individual KEV assertions, but implementers also need a way to discover which organisations publish KEV catalogues and where their machine-readable feeds are located. The GCVE initiative therefore maintains the [GCVE KEV directory](https://github.com/gcve-eu/gcve.eu-directory/blob/main/references.json), a non-mandatory index in which KEV producers can announce their catalogues and exploitation assertions.
+
+A KEV producer can be a vendor, a CSIRT, or any other organisation observing or reporting exploitation. Producers register a stable source entry in the directory and provide one of the following machine-readable endpoints:
+
+- A `bcp_07_url` that directly publishes assertions in the BCP-07 format defined by this document.
+- An `automation_url` that publishes a native KEV format. Where direct BCP-07 output is not available, a converter can transform that feed; the [gcve-eu-kev project](https://github.com/gcve-eu/gcve-eu-kev) provides scripts and examples for such conversions.
+
+Consumers and catalogue operators can use the directory to discover these distributed sources, retrieve or convert their assertions, and combine them into a more complete overview without treating any single producer as the universal source of truth. One implementation of this aggregation workflow is the [GCVE KEV catalogues overview](https://db.gcve.eu/kev-catalogs), provided by Vulnerability-Lookup.
 
 The index is a catalogue of KEV catalogues. It is not authoritative for the content of any listed catalogue and it is not required for a producer to publish BCP-07 KEV assertions. Its purpose is to facilitate discovery, correlation, and stable attribution of KEV catalogues, especially where `gcve.origin_uuid` or `evidence[].gcve.origin_uuid` values need to be resolved to a known source.
 
@@ -465,80 +472,68 @@ The index is a single JSON object (ECMA 404) with a `kev` array. Each item in th
 - **Required:** no
 - **Description:** Licence identifier for the KEV catalogue when available. SPDX identifiers SHOULD be used where an SPDX identifier exists, for example `CC-BY-4.0`, `CC0-1.0`, or `Apache-2.0`.
 
-### JSON Schema for the KEV Source Index
+### JSON Schema for the GCVE KEV Directory Array
+
+The following schema validates only the array of source objects stored below the directory's top-level `kev` key. It does not validate the enclosing directory object.
 
 ~~~json
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://gcve.eu/schemas/bcp-07-kev-source-index.schema.json",
-  "title": "GCVE-BCP-07 KEV Source Index",
-  "type": "object",
-  "additionalProperties": false,
-  "required": [
-    "kev"
-  ],
-  "properties": {
-    "kev": {
-      "type": "array",
-      "description": "Collection of KEV catalogue source descriptions.",
-      "items": {
-        "$ref": "#/$defs/kevSource"
-      }
-    }
-  },
-  "$defs": {
-    "kevSource": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "uuid",
-        "short_name",
-        "url"
-      ],
-      "properties": {
-        "uuid": {
-          "type": "string",
-          "format": "uuid",
-          "description": "Stable UUID identifying the KEV catalogue source."
-        },
-        "short_name": {
-          "type": "string",
-          "description": "Short human-readable name for the KEV catalogue source."
-        },
-        "gcve_gna_id": {
-          "type": "integer",
-          "minimum": 0,
-          "maximum": 65535,
-          "description": "GNA ID associated with the source, when available."
-        },
-        "url": {
-          "type": "string",
-          "format": "uri",
-          "description": "Human-facing URL for the KEV catalogue or source."
-        },
-        "automation_url": {
-          "type": "string",
-          "format": "uri",
-          "description": "Machine-readable URL for the source catalogue in its native or preferred automation format."
-        },
-        "bcp_07_url": {
-          "type": "string",
-          "format": "uri",
-          "description": "Machine-readable URL where KEV data can be retrieved in BCP-07 format."
-        },
-        "description": {
-          "type": "string",
-          "description": "Human-readable description of the KEV catalogue source."
-        },
-        "meta": {
-          "type": "object",
-          "description": "Optional extensible metadata about the KEV catalogue source.",
-          "additionalProperties": true,
-          "properties": {
-            "license": {
-              "type": "string",
-              "description": "Licence identifier for the KEV catalogue; use an SPDX identifier when available."
-            }
+  "$id": "https://gcve.eu/schemas/bcp-07-kev-directory-array.schema.json",
+  "title": "GCVE-BCP-07 KEV Directory Array",
+  "description": "The array of KEV catalogue sources stored below the directory's kev key.",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+      "uuid",
+      "short_name",
+      "url"
+    ],
+    "properties": {
+      "uuid": {
+        "type": "string",
+        "format": "uuid",
+        "description": "Stable UUID identifying the KEV catalogue source."
+      },
+      "short_name": {
+        "type": "string",
+        "description": "Short human-readable name for the KEV catalogue source."
+      },
+      "gcve_gna_id": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 65535,
+        "description": "GNA ID associated with the source, when available."
+      },
+      "url": {
+        "type": "string",
+        "format": "uri",
+        "description": "Human-facing URL for the KEV catalogue or source."
+      },
+      "automation_url": {
+        "type": "string",
+        "format": "uri",
+        "description": "Machine-readable URL for the source catalogue in its native or preferred automation format."
+      },
+      "bcp_07_url": {
+        "type": "string",
+        "format": "uri",
+        "description": "Machine-readable URL where KEV data can be retrieved in BCP-07 format."
+      },
+      "description": {
+        "type": "string",
+        "description": "Human-readable description of the KEV catalogue source."
+      },
+      "meta": {
+        "type": "object",
+        "description": "Optional extensible metadata about the KEV catalogue source.",
+        "additionalProperties": true,
+        "properties": {
+          "license": {
+            "type": "string",
+            "description": "Licence identifier for the KEV catalogue; use an SPDX identifier when available."
           }
         }
       }


### PR DESCRIPTION
### Motivation
- Bump the BCP-07 document version to reflect editorial and structural updates and set the publication `Date` to `2026-09-01`.
- Replace the previous KEV source index guidance with a more explicit GCVE KEV Directory model to improve discovery and stable attribution of KEV producers.
- Simplify and clarify the JSON Schema that consumers use to validate directory entries by focusing validation on the `kev` array items.

### Description
- Updated frontmatter fields `Version` to `2.2` and `Date` to `2026-09-01` in `content/bcp/gcve-bcp-07.md`.
- Replaced the "KEV Source Index" section with "GCVE KEV Directory and Source Index Format", added producer guidance describing `bcp_07_url` and `automation_url` endpoints, and added references to the `gcve-eu-kev` conversion project and the Vulnerability-Lookup overview.
- Reworked the JSON Schema section: changed the `$id`, `title`, and schema layout so the schema now validates the directory's array of source objects (the `kev` array items) rather than the enclosing object, keeping required properties `uuid`, `short_name`, and `url` and the existing fields like `gcve_gna_id`, `automation_url`, `bcp_07_url`, and `meta`.
- Applied editorial clarifications and updated links to point to the dedicated GCVE directory repository and examples.

### Testing
- No automated tests were run on the modified content.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9656195ab88324a2024d3b0c3d8d19)