### PR TITLE
Add recent news box to homepage (shortcode + styles)

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -574,6 +574,112 @@ body {
   line-height: 1.65;
 }
 
+.gcve-news-box {
+  margin: 2.75rem 0 3.25rem;
+  padding: clamp(1.35rem, 3vw, 2rem);
+  border: 1px solid var(--gcve-border);
+  border-radius: 1.5rem;
+  background:
+    radial-gradient(circle at 95% 0, rgba(34, 195, 223, 0.13), transparent 20rem),
+    var(--gcve-card);
+  box-shadow: var(--gcve-shadow);
+  backdrop-filter: blur(14px);
+}
+
+.gcve-news-header {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.4rem;
+}
+
+.gcve-news-header .gcve-eyebrow {
+  margin-bottom: 0.25rem;
+}
+
+.gcve-news-header h2 {
+  margin: 0;
+  border: 0;
+  color: var(--gcve-ink);
+  font-size: clamp(1.6rem, 3vw, 2.15rem);
+  letter-spacing: -0.035em;
+}
+
+.gcve-news-all {
+  flex: 0 0 auto;
+  color: var(--gcve-blue);
+  font-weight: 750;
+  text-decoration: none;
+}
+
+.gcve-news-all:hover {
+  text-decoration: underline;
+  text-underline-offset: 0.2em;
+}
+
+.gcve-news-list {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.gcve-news-item {
+  min-width: 0;
+  padding: 1.15rem;
+  border: 1px solid rgba(38, 100, 255, 0.12);
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.58);
+}
+
+.dark .gcve-news-item {
+  border-color: rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.045);
+}
+
+.gcve-news-item time {
+  color: var(--gcve-muted);
+  font-size: 0.78rem;
+  font-weight: 750;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.gcve-news-item h3 {
+  margin: 0.55rem 0 0.65rem;
+  font-size: 1.05rem;
+  line-height: 1.35;
+}
+
+.gcve-news-item h3 a {
+  color: var(--gcve-ink);
+  text-decoration: none;
+}
+
+.gcve-news-item h3 a:hover {
+  color: var(--gcve-blue);
+}
+
+.gcve-news-item p {
+  margin: 0;
+  color: var(--gcve-muted);
+  font-size: 0.9rem;
+  line-height: 1.55;
+}
+
+@media (max-width: 800px) {
+  .gcve-news-list {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 520px) {
+  .gcve-news-header {
+    align-items: start;
+    flex-direction: column;
+  }
+}
+
 .hextra-cards {
   gap: 1rem !important;
 }

--- a/content/_index.md
+++ b/content/_index.md
@@ -30,6 +30,8 @@ The **Global CVE (GCVE)** allocation system is a new, decentralized approach to 
 
 While remaining compatible with the traditional CVE system, GCVE introduces **GCVE Numbering Authorities (GNAs)**. GNAs are independent entities that can allocate identifiers without relying on a centralised block distribution system or rigid policy enforcement.
 
+{{< recent-news >}}
+
 ## Explore GCVE
 
 <p class="gcve-section-intro">Start with the core concepts, follow the latest updates, or jump directly to the machine-readable data and vulnerability intelligence services.</p>

--- a/layouts/shortcodes/recent-news.html
+++ b/layouts/shortcodes/recent-news.html
@@ -1,0 +1,22 @@
+{{- $news := where site.RegularPages "Section" "news" -}}
+{{- $news = first 3 (sort $news "Date" "desc") -}}
+<section class="gcve-news-box" aria-labelledby="gcve-recent-news-heading">
+  <div class="gcve-news-header">
+    <div>
+      <p class="gcve-eyebrow">From the community</p>
+      <h2 id="gcve-recent-news-heading">Recent news</h2>
+    </div>
+    <a class="gcve-news-all" href="{{ relURL "news/" }}">View all news <span aria-hidden="true">&rarr;</span></a>
+  </div>
+  <div class="gcve-news-list">
+    {{- range $news }}
+      <article class="gcve-news-item">
+        <time datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "2 January 2006" }}</time>
+        <h3><a href="{{ .RelPermalink }}">{{ .Title }}</a></h3>
+        {{- with or .Description .Summary }}
+          <p>{{ . | plainify | truncate 155 }}</p>
+        {{- end }}
+      </article>
+    {{- end }}
+  </div>
+</section>


### PR DESCRIPTION
### Motivation

- Surface the latest news on the homepage so visitors can quickly see recent announcements and link to the full news archive.  

### Description

- Added a reusable Hugo shortcode `layouts/shortcodes/recent-news.html` that selects the three newest pages from the `news` section and renders date, title, summary, and a link to the news index.  
- Inserted the shortcode into the homepage at `content/_index.md` using `{{< recent-news >}}` between the intro and the “Explore GCVE” cards.  
- Added styling for the news box and its components in `assets/css/custom.css`, including light/dark theme handling, a three-column desktop grid and responsive single-column layout for small screens.  

### Testing

- Ran a small verification script with `python3` that checked the homepage includes `{{< recent-news >}}`, validated the shortcode uses `first 3 (sort $news "Date" "desc")`, and confirmed the main CSS selectors (`.gcve-news-box`, `.gcve-news-list`, `.gcve-news-item`) are present; this check passed.  
- Ran `git diff --check` to ensure there are no whitespace/patch issues; no problems were reported.  
- Attempts to run a local site build with `hugo --minify` failed because `hugo` is not installed in the environment, and attempts to install or download Hugo (`apt-get install hugo` and `curl` download) failed due to repository/network restrictions, so a full rendered build could not be produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a983d8acc5883258973020553744655)